### PR TITLE
Added additional channel to access posted event

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,10 +18,15 @@ blocks:
 
   - name: Run tests
     task:
+      prologue:
+        commands:
+          - export "SEMAPHORE_GIT_DIR=$(go env GOPATH)/src/github.com/workos-inc/${SEMAPHORE_PROJECT_NAME}"
+          - export "PATH=$(go env GOPATH)/bin:${PATH}"
+          - mkdir -vp "${SEMAPHORE_GIT_DIR}" "$(go env GOPATH)/bin"
       jobs:
       - name: go test
         commands:
           - checkout
           - sem-version go 1.12
-          - go get -d -v ./...
+          - go get github.com/stretchr/testify/assert
           - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The resulting event being sent to WorkOS looks like:
 
 The time the event occured is automatically populated for you when the event is created.
 
-All events are published to WorkOS asyncronously by default. `auditlog.Publish` returns an error channel for you so you can wait for a response from WorkOS should you need a blocking operation.
+All events are published to WorkOS asyncronously by default. `auditlog.Publish` returns an event and error channel for you so you can wait for a response from WorkOS should you need a blocking operation.
 
 ```go
 user := User{
@@ -88,11 +88,13 @@ event.SetGroup(organization)
 event.SetActor(user)
 event.SetTarget(user)
 event.SetLocation("1.1.1.1")
-ch := event.Publish()
-err := <-ch
+errCh, eventCh := event.Publish()
+err := <-errCh
+postedEvent := <-eventCh
 if err != nil {
   fmt.Printf("Had a problem writing the event: %q %q\n", event, err)
 }
+fmt.Println(postedEvent.ID)
 ```
 
 ## Configuring An Auditable Interface
@@ -150,7 +152,9 @@ event.AddMetadata(map[string]interface{}{
 	"body_was": bodyWas,
 	"body": comment.Body,
 })
-err := event.Publish()
+errCh, eventCh := event.Publish()
+err := <-errCh
+postedEvent := <-eventCh
 if err != nil {
 	fmt.Printf("Had a problem writing the event: %q %q\n", event, err)
 }
@@ -205,7 +209,9 @@ event.SetLocation("1.1.1.1")
 event.AddMetadata(map[string]interface{}{
 	"parent_tweet": tweet.ParentTweet,
 })
-err := event.Publish()
+errCh, eventCh := event.Publish()
+err := <-errCh
+postedEvent := <-eventCh
 if err != nil {
 	fmt.Printf("Had a problem writing the event: %q %q\n", event, err)
 }
@@ -294,7 +300,9 @@ http.HandleFunc("/login", func(w http.ResponseWriter, req *http.Request) {
 	event.SetGroup(user)
 	event.SetActor(user)
 	event.SetTarget(user)
-	err := event.Publish()
+	errCh, eventCh := event.Publish()
+  err := <-errCh
+  postedEvent := <-eventCh
 	if err != nil {
 		fmt.Printf("Had a problem writing the event: %q %q\n", event, err)
 	}

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ http.HandleFunc("/login", func(w http.ResponseWriter, req *http.Request) {
 	event.SetActor(user)
 	event.SetTarget(user)
 	errCh, eventCh := event.Publish()
-  err := <-errCh
+	err := <-errCh
   postedEvent := <-eventCh
 	if err != nil {
 		fmt.Printf("Had a problem writing the event: %q %q\n", event, err)

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ http.HandleFunc("/login", func(w http.ResponseWriter, req *http.Request) {
 	event.SetTarget(user)
 	errCh, eventCh := event.Publish()
 	err := <-errCh
-  postedEvent := <-eventCh
+	postedEvent := <-eventCh
 	if err != nil {
 		fmt.Printf("Had a problem writing the event: %q %q\n", event, err)
 	}

--- a/auditlog/event.go
+++ b/auditlog/event.go
@@ -223,7 +223,7 @@ func (e Event) Publish() (chan *Event, chan error) {
 		eventCh <- event
 	}()
 
-	return errCh, eventCh
+	return eventCh, errCh
 }
 
 // PublishEvent delivers the Audit Log event to WorkOS.

--- a/auditlog/event.go
+++ b/auditlog/event.go
@@ -200,7 +200,7 @@ func (e Event) addMetadata(key string, value interface{}) error {
 }
 
 // Publish delivers the event to WorkOS asyncronously.
-func (e Event) Publish() (chan error, chan *Event) {
+func (e Event) Publish() (chan *Event, chan error) {
 	// Add the global metadata to the Event's metadata
 	for k, v := range globalMetadata {
 		e.Metadata[k] = v

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 		event.SetActor(u)
 		event.SetGroup(u)
 		event.SetTarget(u)
-		errCh, eventCh := event.Publish()
+		eventCh, errCh := event.Publish()
 		err := <-errCh
 		newEvent := <-eventCh
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -39,15 +39,16 @@ func main() {
 		event.SetActor(u)
 		event.SetGroup(u)
 		event.SetTarget(u)
-		ch := event.Publish()
-		err := <-ch
+		errCh, eventCh := event.Publish()
+		err := <-errCh
+		newEvent := <-eventCh
 		if err != nil {
 			// Call out to sentry
 			fmt.Fprintf(w, err.Error())
 			return
 		}
 
-		body, _ := json.Marshal(event)
+		body, _ := json.Marshal(newEvent)
 		fmt.Fprintf(w, string(body))
 	})
 


### PR DESCRIPTION
This lets the integrator immediately see the event after it is published to the Audit Log.
For example:

```go
u := user{
	Email:      "me@domain.com",
	DatabaseID: 1,
}

event := auditlog.NewEventWithHTTP("user.login", auditlog.Create, req)
event.SetActor(u)
event.SetGroup(u)
event.SetTarget(u)

errCh, eventCh := event.Publish()
err := <-errCh
newEvent := <-eventCh
if err != nil {
	// Call out to sentry
	fmt.Fprintf(w, err.Error())
	return
}

body, _ := json.Marshal(newEvent)
fmt.Fprintf(w, string(body))
```