### PR TITLE
Simplify sso usage

### DIFF
--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -16,18 +16,16 @@ import (
 )
 
 func main() {
-    sso.SetAPIKey("my_api_key")
+    sso.Init("my_api_key", "my_workos_project_id")
 
     http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
         Domain:      "mydomain.com",
-        ProjectID:   "my_workos_project_id",
         RedirectURI: "https://mydomain.com/callback",
     }))
 
     http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
         profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
             Code:        r.URL.Query().Get("code"),
-            ProjectID:   "my_workos_project_id",
             RedirectURI: "https://mydomain.com/callback",
         })
         if err != nil {

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -1,0 +1,46 @@
+# sso
+
+[![godoc](https://godoc.org/github.com/workos-inc/workos-go/pkg/sso?status.svg)](https://godoc.org/github.com/workos-inc/workos-go/pkg/sso)
+
+A go package to request WorkOS SSO API.
+
+## How it works
+
+```go
+import (
+    "context"
+    "fmt"
+    "net/http"
+
+    "github.com/workos-inc/workos-go/pkg/sso"
+)
+
+func main() {
+    sso.SetAPIKey("my_api_key")
+
+    http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
+        Domain:      "mydomain.com",
+        ProjectID:   "my_workos_project_id",
+        RedirectURI: "https://mydomain.com/callback",
+    }))
+
+    http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+        profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
+            Code:        r.URL.Query().Get("code"),
+            ProjectID:   "my_workos_project_id",
+            RedirectURI: "https://mydomain.com/callback",
+        })
+        if err != nil {
+            // Handle the error ...
+            return
+        }
+
+        // Handle the profile ...
+        fmt.Println(profile)
+    })
+
+    if err := http.ListenAndServe("your_server_addr", nil); err != nil {
+        panic(err)
+    }
+}
+```

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -16,17 +16,19 @@ import (
 )
 
 func main() {
-    sso.Init("my_api_key", "my_workos_project_id")
+    sso.Configure(
+        "xxxxx",                            // WorkOS api key
+        "project_xxxxx",                    // WorkOS project id
+        "https://mydomain.com/callback",    // Redirect URI
+    )
 
     http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
-        Domain:      "mydomain.com",
-        RedirectURI: "https://mydomain.com/callback",
+        Domain: "mydomain.com",
     }))
 
     http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
         profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
-            Code:        r.URL.Query().Get("code"),
-            RedirectURI: "https://mydomain.com/callback",
+            Code:   r.URL.Query().Get("code"),
         })
         if err != nil {
             // Handle the error ...

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -26,19 +26,28 @@ type Client struct {
 	// The WorkOS api key. It can be found in
 	// https://dashboard.workos.com/api-keys.
 	//
-	// Client panics when there is no api key set.
+	// REQUIRED.
 	APIKey string
 
 	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ).
 	//
-	// Client panics when there is no project id set.
+	// REQUIRED.
 	ProjectID string
 
-	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
+	// The callback URL where your app redirects the user-agent after an
+	// authorization code is granted (eg. https://foo.com/callback).
+	//
+	// REQUIRED.
+	RedirectURI string
+
+	// The endpoint to WorkOS API.
+	//
+	// Defaults to https://api.workos.com.
 	Endpoint string
 
-	// The http.Client that is used to send request to WorkOS. Defaults to
-	// http.Client.
+	// The http.Client that is used to send request to WorkOS.
+	//
+	// Defaults to http.Client.
 	HTTPClient *http.Client
 
 	once                     sync.Once
@@ -65,14 +74,10 @@ type GetAuthorizationURLOptions struct {
 	// The app/company domain without without protocol (eg. example.com).
 	Domain string
 
-	// The callback URL where your app redirects the user-agent after an
-	// authorization code is granted (eg. https://foo.com/callback).
-	RedirectURI string
-
 	// A unique identifier used to manage state across authorization
 	// transactions (eg. 1234zyx).
 	//
-	// Optional.
+	// OPTIONAL.
 	State string
 }
 
@@ -84,7 +89,7 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 	query := make(url.Values, 5)
 	query.Set("domain", opts.Domain)
 	query.Set("client_id", c.ProjectID)
-	query.Set("redirect_uri", opts.RedirectURI)
+	query.Set("redirect_uri", c.RedirectURI)
 	query.Set("response_type", "code")
 
 	if opts.State != "" {
@@ -105,11 +110,6 @@ type GetProfileOptions struct {
 	// An opaque string provided by the authorization server. It will be
 	// exchanged for an Access Token when the user’s profile is sent.
 	Code string
-
-	// The callback URL where your app redirects the user-agent after an
-	// authorization code is granted (eg. https://foo.com/callback). Must be the
-	// one used to generate the authorization url.
-	RedirectURI string
 }
 
 // Profile contains information about a user authentication.
@@ -148,7 +148,7 @@ func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profil
 	query := make(url.Values, 5)
 	query.Set("client_id", c.ProjectID)
 	query.Set("client_secret", c.APIKey)
-	query.Set("redirect_uri", opts.RedirectURI)
+	query.Set("redirect_uri", c.RedirectURI)
 	query.Set("grant_type", "authorization_code")
 	query.Set("code", opts.Code)
 	req.URL.RawQuery = query.Encode()

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -1,0 +1,174 @@
+package sso
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConnectionType represents a connection type.
+type ConnectionType string
+
+// Constants that enumerate the available connection types.
+const (
+	AzureSAML ConnectionType = "AzureSAML"
+	OktaSAML  ConnectionType = "OktaSAML"
+)
+
+// Client represents a client that fetch SSO data from WorkOS API.
+type Client struct {
+	// The WorkOS api key. It can be found in
+	// https://dashboard.workos.com/api-keys.
+	APIKey string
+
+	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
+	Endpoint string
+
+	// The http.Client that is used to send request to WorkOS. Defaults to
+	// http.Client.
+	HTTPClient *http.Client
+
+	once                     sync.Once
+	authorizationURLEndpoint string
+	profileEndpoint          string
+}
+
+func (c *Client) init() {
+	if c.Endpoint == "" {
+		c.Endpoint = "https://api.workos.com"
+	}
+	c.Endpoint = strings.TrimSuffix(c.Endpoint, "/")
+	c.authorizationURLEndpoint = c.Endpoint + "/sso/authorize"
+	c.profileEndpoint = c.Endpoint + "/sso/token"
+
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{Timeout: time.Second * 15}
+	}
+}
+
+// GetAuthorizationURLOptions contains the options to pass in order to generate
+// an authorization url.
+type GetAuthorizationURLOptions struct {
+	// The app/company domain without without protocol (eg. example.com).
+	Domain string
+
+	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ).
+	ProjectID string
+
+	// The callback URL where your app redirects the user-agent after an
+	// authorization code is granted (eg. https://foo.com/callback).
+	RedirectURI string
+
+	// A unique identifier used to manage state across authorization
+	// transactions (eg. 1234zyx).
+	//
+	// Optional.
+	State string
+}
+
+// GetAuthorizationURL returns an authorization url generated with the given
+// options.
+func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL, error) {
+	c.once.Do(c.init)
+
+	query := make(url.Values, 5)
+	query.Set("domain", opts.Domain)
+	query.Set("client_id", opts.ProjectID)
+	query.Set("redirect_uri", opts.RedirectURI)
+	query.Set("response_type", "code")
+
+	if opts.State != "" {
+		query.Set("state", opts.State)
+	}
+
+	u, err := url.ParseRequestURI(c.authorizationURLEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	u.RawQuery = query.Encode()
+	return u, nil
+}
+
+// GetProfileOptions contains the options to pass in order to get a user profile.
+type GetProfileOptions struct {
+	// An opaque string provided by the authorization server. It will be
+	// exchanged for an Access Token when the user’s profile is sent.
+	Code string
+
+	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ). Must be
+	// the one used to generate the authorization url.
+	ProjectID string
+
+	// The callback URL where your app redirects the user-agent after an
+	// authorization code is granted (eg. https://foo.com/callback). Must be the
+	// one used to generate the authorization url.
+	RedirectURI string
+}
+
+// Profile contains information about a user authentication.
+type Profile struct {
+	// The user ID.
+	ID string
+
+	// An unique alphanumeric identifier for a Profile’s identity provider.
+	IdpID string
+
+	// The connection type.
+	ConnectionType ConnectionType
+
+	// The user email.
+	Email string
+
+	// The user first name. Can be empty.
+	FirstName string
+
+	// The user last name. Can be empty.
+	LastName string
+}
+
+// GetProfile returns a profile describing the user that authenticated with
+// WorkOS SSO.
+func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
+	c.once.Do(c.init)
+
+	query := make(url.Values, 5)
+	query.Set("client_id", opts.ProjectID)
+	query.Set("client_secret", c.APIKey)
+	query.Set("redirect_uri", opts.RedirectURI)
+	query.Set("grant_type", "authorization_code")
+	query.Set("code", opts.Code)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.profileEndpoint,
+		strings.NewReader(query.Encode()),
+	)
+	if err != nil {
+		return Profile{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "workos-go/"+version)
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return Profile{}, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return Profile{}, errors.New(res.Status)
+	}
+
+	var profile Profile
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&profile)
+	return profile, err
+}

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -138,11 +138,7 @@ type Profile struct {
 func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
 	c.once.Do(c.init)
 
-	req, err := http.NewRequest(
-		http.MethodPost,
-		c.profileEndpoint,
-		nil,
-	)
+	req, err := http.NewRequest(http.MethodPost, c.profileEndpoint, nil)
 	if err != nil {
 		return Profile{}, err
 	}

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -25,7 +25,14 @@ const (
 type Client struct {
 	// The WorkOS api key. It can be found in
 	// https://dashboard.workos.com/api-keys.
+	//
+	// Client panics when there is no api key set.
 	APIKey string
+
+	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ).
+	//
+	// Client panics when there is no project id set.
+	ProjectID string
 
 	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
 	Endpoint string
@@ -58,9 +65,6 @@ type GetAuthorizationURLOptions struct {
 	// The app/company domain without without protocol (eg. example.com).
 	Domain string
 
-	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ).
-	ProjectID string
-
 	// The callback URL where your app redirects the user-agent after an
 	// authorization code is granted (eg. https://foo.com/callback).
 	RedirectURI string
@@ -79,7 +83,7 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 
 	query := make(url.Values, 5)
 	query.Set("domain", opts.Domain)
-	query.Set("client_id", opts.ProjectID)
+	query.Set("client_id", c.ProjectID)
 	query.Set("redirect_uri", opts.RedirectURI)
 	query.Set("response_type", "code")
 
@@ -101,10 +105,6 @@ type GetProfileOptions struct {
 	// An opaque string provided by the authorization server. It will be
 	// exchanged for an Access Token when the user’s profile is sent.
 	Code string
-
-	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ). Must be
-	// the one used to generate the authorization url.
-	ProjectID string
 
 	// The callback URL where your app redirects the user-agent after an
 	// authorization code is granted (eg. https://foo.com/callback). Must be the
@@ -146,7 +146,7 @@ func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profil
 	req.Header.Set("User-Agent", "workos-go/"+version)
 
 	query := make(url.Values, 5)
-	query.Set("client_id", opts.ProjectID)
+	query.Set("client_id", c.ProjectID)
 	query.Set("client_secret", c.APIKey)
 	query.Set("redirect_uri", opts.RedirectURI)
 	query.Set("grant_type", "authorization_code")

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -1,0 +1,141 @@
+package sso
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientAuthorizeURL(t *testing.T) {
+	tests := []struct {
+		scenario string
+		options  GetAuthorizationURLOptions
+		expected string
+	}{
+		{
+			scenario: "generate url",
+			options: GetAuthorizationURLOptions{
+				Domain:      "lyft.com",
+				ProjectID:   "proj_123",
+				RedirectURI: "https://example.com/sso/workos/callback",
+			},
+			expected: "https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
+		},
+		{
+			scenario: "generate url with state",
+			options: GetAuthorizationURLOptions{
+				Domain:      "lyft.com",
+				ProjectID:   "proj_123",
+				RedirectURI: "https://example.com/sso/workos/callback",
+				State:       "custom state",
+			},
+			expected: "https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			client := Client{}
+			u, err := client.GetAuthorizationURL(test.options)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, u.String())
+		})
+	}
+}
+
+func TestClientGetProfile(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetProfileOptions
+		expected Profile
+		err      bool
+	}{
+		{
+			scenario: "request without api key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "request returns a profile",
+			client:   &Client{APIKey: "test"},
+			options: GetProfileOptions{
+				Code:        "authorization_code",
+				ProjectID:   "proj_123",
+				RedirectURI: "https://exmaple.com/sso/workos/callback",
+			},
+			expected: Profile{
+				ID:             "proj_123",
+				IdpID:          "123",
+				ConnectionType: OktaSAML,
+				Email:          "foo@test.com",
+				FirstName:      "foo",
+				LastName:       "bar",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(profileTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			profile, err := client.GetProfile(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, profile)
+		})
+	}
+}
+
+func profileTestHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/sso/token" {
+		fmt.Println("path:", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if auth := r.Header.Get("Authorization"); auth != "Bearer test" {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	if contentType := r.Header.Get("Content-Type"); contentType != "application/x-www-form-urlencoded" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	b, err := json.Marshal(Profile{
+		ID:             "proj_123",
+		IdpID:          "123",
+		ConnectionType: OktaSAML,
+		Email:          "foo@test.com",
+		FirstName:      "foo",
+		LastName:       "bar",
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(b)
+}

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -22,7 +22,6 @@ func TestClientAuthorizeURL(t *testing.T) {
 			scenario: "generate url",
 			options: GetAuthorizationURLOptions{
 				Domain:      "lyft.com",
-				ProjectID:   "proj_123",
 				RedirectURI: "https://example.com/sso/workos/callback",
 			},
 			expected: "https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
@@ -31,7 +30,6 @@ func TestClientAuthorizeURL(t *testing.T) {
 			scenario: "generate url with state",
 			options: GetAuthorizationURLOptions{
 				Domain:      "lyft.com",
-				ProjectID:   "proj_123",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
 			},
@@ -41,7 +39,11 @@ func TestClientAuthorizeURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			client := Client{}
+			client := Client{
+				APIKey:    "test",
+				ProjectID: "proj_123",
+			}
+
 			u, err := client.GetAuthorizationURL(test.options)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, u.String())
@@ -64,10 +66,12 @@ func TestClientGetProfile(t *testing.T) {
 		},
 		{
 			scenario: "request returns a profile",
-			client:   &Client{APIKey: "test"},
+			client: &Client{
+				APIKey:    "test",
+				ProjectID: "proj_123",
+			},
 			options: GetProfileOptions{
 				Code:        "authorization_code",
-				ProjectID:   "proj_123",
 				RedirectURI: "https://exmaple.com/sso/workos/callback",
 			},
 			expected: Profile{

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -21,17 +21,15 @@ func TestClientAuthorizeURL(t *testing.T) {
 		{
 			scenario: "generate url",
 			options: GetAuthorizationURLOptions{
-				Domain:      "lyft.com",
-				RedirectURI: "https://example.com/sso/workos/callback",
+				Domain: "lyft.com",
 			},
 			expected: "https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
 		},
 		{
 			scenario: "generate url with state",
 			options: GetAuthorizationURLOptions{
-				Domain:      "lyft.com",
-				RedirectURI: "https://example.com/sso/workos/callback",
-				State:       "custom state",
+				Domain: "lyft.com",
+				State:  "custom state",
 			},
 			expected: "https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
@@ -40,8 +38,9 @@ func TestClientAuthorizeURL(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
 			client := Client{
-				APIKey:    "test",
-				ProjectID: "proj_123",
+				APIKey:      "test",
+				ProjectID:   "proj_123",
+				RedirectURI: "https://example.com/sso/workos/callback",
 			}
 
 			u, err := client.GetAuthorizationURL(test.options)
@@ -67,12 +66,12 @@ func TestClientGetProfile(t *testing.T) {
 		{
 			scenario: "request returns a profile",
 			client: &Client{
-				APIKey:    "test",
-				ProjectID: "proj_123",
+				APIKey:      "test",
+				ProjectID:   "proj_123",
+				RedirectURI: "https://exmaple.com/sso/workos/callback",
 			},
 			options: GetProfileOptions{
-				Code:        "authorization_code",
-				RedirectURI: "https://exmaple.com/sso/workos/callback",
+				Code: "authorization_code",
 			},
 			expected: Profile{
 				ID:             "proj_123",

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -2,18 +2,16 @@
 //
 // Example:
 //   func main() {
-// 	     sso.SetAPIKey("my_api_key")
+// 	     sso.Init("my_api_key", "my_workos_project_id")
 //
 //       http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
 // 	         Domain:      "mydomain.com",
-// 	         ProjectID:   "my_workos_project_id",
 // 	         RedirectURI: "https://mydomain.com/callback",
 //       }))
 //
 // 	     http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 // 	         profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
 // 	             Code:        r.URL.Query().Get("code"),
-// 	             ProjectID:   "my_workos_project_id",
 // 	             RedirectURI: "https://mydomain.com/callback",
 // 	         })
 // 	         if err != nil {

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -2,17 +2,19 @@
 //
 // Example:
 //   func main() {
-// 	     sso.Init("my_api_key", "my_workos_project_id")
+//       sso.Configure(
+//           "xxxxx",							// WorkOS api key
+//           "project_xxxxx",					// WorkOS project id
+//           "https://mydomain.com/callback",	// Redirect URI
+//       )
 //
 //       http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
-// 	         Domain:      "mydomain.com",
-// 	         RedirectURI: "https://mydomain.com/callback",
+// 	         Domain:	"mydomain.com",
 //       }))
 //
 // 	     http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 // 	         profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
-// 	             Code:        r.URL.Query().Get("code"),
-// 	             RedirectURI: "https://mydomain.com/callback",
+// 	             Code:	r.URL.Query().Get("code"),
 // 	         })
 // 	         if err != nil {
 // 	             // Handle the error ...
@@ -40,17 +42,18 @@ const (
 )
 
 var (
-	// DefaultClient is the client used by SetAPIKey, GetAuthorizationURL,
-	// GetProfile and Login functions.
+	// DefaultClient is the client used by GetAuthorizationURL, GetProfile and
+	// Login functions.
 	DefaultClient = &Client{}
 )
 
-// Init initializes default client api key and project id.
-//
-// Must be called before using GetAuthorizationURL, GetProfile or Login.
-func Init(apiKey, projectID string) {
+// Configure configures the default client that is used by GetAuthorizationURL,
+// GetProfile and Login.
+// It must be called before using those functions.
+func Configure(apiKey, projectID, redirectURI string) {
 	DefaultClient.APIKey = apiKey
 	DefaultClient.ProjectID = projectID
+	DefaultClient.RedirectURI = redirectURI
 }
 
 // GetAuthorizationURL returns an authorization url generated with the given

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -47,9 +47,12 @@ var (
 	DefaultClient = &Client{}
 )
 
-// SetAPIKey set the api key to use with
-func SetAPIKey(apiKey string) {
+// Init initializes default client api key and project id.
+//
+// Must be called before using GetAuthorizationURL, GetProfile or Login.
+func Init(apiKey, projectID string) {
 	DefaultClient.APIKey = apiKey
+	DefaultClient.ProjectID = projectID
 }
 
 // GetAuthorizationURL returns an authorization url generated with the given

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -1,0 +1,80 @@
+// Package sso provide functions and client to communicate with WorkOS SSO API.
+//
+// Example:
+//   func main() {
+// 	     sso.SetAPIKey("my_api_key")
+//
+//       http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
+// 	         Domain:      "mydomain.com",
+// 	         ProjectID:   "my_workos_project_id",
+// 	         RedirectURI: "https://mydomain.com/callback",
+//       }))
+//
+// 	     http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+// 	         profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
+// 	             Code:        r.URL.Query().Get("code"),
+// 	             ProjectID:   "my_workos_project_id",
+// 	             RedirectURI: "https://mydomain.com/callback",
+// 	         })
+// 	         if err != nil {
+// 	             // Handle the error ...
+// 	             return
+// 	         }
+//
+// 	         // Handle the profile ...
+// 	         fmt.Println(profile)
+//       })
+//
+//       if err := http.ListenAndServe("your_server_addr", nil); err != nil {
+//           panic(err)
+//       }
+//   }
+package sso
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+const (
+	version = "0.0.1"
+)
+
+var (
+	// DefaultClient is the client used by SetAPIKey, GetAuthorizationURL,
+	// GetProfile and Login functions.
+	DefaultClient = &Client{}
+)
+
+// SetAPIKey set the api key to use with
+func SetAPIKey(apiKey string) {
+	DefaultClient.APIKey = apiKey
+}
+
+// GetAuthorizationURL returns an authorization url generated with the given
+// options.
+func GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL, error) {
+	return DefaultClient.GetAuthorizationURL(opts)
+}
+
+// GetProfile returns a profile describing the user that authenticated with
+// WorkOS SSO.
+func GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
+	return DefaultClient.GetProfile(ctx, opts)
+}
+
+// Login return a http.Handler that redirects client to the appropriate
+// login provider.
+func Login(opts GetAuthorizationURLOptions) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, err := GetAuthorizationURL(opts)
+		if err != nil {
+			w.WriteHeader(http.StatusInsufficientStorage)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		http.Redirect(w, r, u.String(), http.StatusSeeOther)
+	})
+}

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	version = "0.0.1"
+	version = "0.0.2"
 )
 
 var (
@@ -70,7 +70,7 @@ func Login(opts GetAuthorizationURLOptions) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, err := GetAuthorizationURL(opts)
 		if err != nil {
-			w.WriteHeader(http.StatusInsufficientStorage)
+			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
 			return
 		}

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -31,8 +31,7 @@ func TestLogin(t *testing.T) {
 	wg.Add(1)
 
 	mux.Handle("/login", Login(GetAuthorizationURLOptions{
-		Domain:      "lyft.com",
-		RedirectURI: redirectURI,
+		Domain: "lyft.com",
 	}))
 
 	mux.HandleFunc("/sso/authorize", func(w http.ResponseWriter, r *http.Request) {
@@ -50,8 +49,7 @@ func TestLogin(t *testing.T) {
 
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		p, err := GetProfile(context.Background(), GetProfileOptions{
-			Code:        "authorization_code",
-			RedirectURI: redirectURI,
+			Code: "authorization_code",
 		})
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -69,7 +67,7 @@ func TestLogin(t *testing.T) {
 		Endpoint:   server.URL,
 		HTTPClient: server.Client(),
 	}
-	Init("test", "proj_123")
+	Configure("test", "proj_123", redirectURI)
 
 	res, err := server.Client().Get(server.URL + "/login")
 	require.NoError(t, err)

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -1,0 +1,83 @@
+package sso
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogin(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	redirectURI := server.URL + "/callback"
+
+	profile := Profile{}
+	expectedProfile := Profile{
+		ID:             "proj_123",
+		IdpID:          "123",
+		ConnectionType: OktaSAML,
+		Email:          "foo@test.com",
+		FirstName:      "foo",
+		LastName:       "bar",
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	mux.Handle("/login", Login(GetAuthorizationURLOptions{
+		Domain:      "lyft.com",
+		ProjectID:   "proj_123",
+		RedirectURI: redirectURI,
+	}))
+
+	mux.HandleFunc("/sso/authorize", func(w http.ResponseWriter, r *http.Request) {
+		redirect := r.URL.Query().Get("redirect_uri")
+
+		res, err := server.Client().Get(redirect)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		res.Body.Close()
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		p, err := GetProfile(context.Background(), GetProfileOptions{
+			Code:        "authorization_code",
+			ProjectID:   "proj_123",
+			RedirectURI: redirectURI,
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		profile = p
+
+		w.WriteHeader(http.StatusOK)
+		wg.Done()
+	})
+
+	mux.HandleFunc("/sso/token", profileTestHandler)
+
+	DefaultClient = &Client{
+		Endpoint:   server.URL,
+		HTTPClient: server.Client(),
+	}
+	SetAPIKey("test")
+
+	res, err := server.Client().Get(server.URL + "/login")
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	wg.Wait()
+	require.Equal(t, expectedProfile, profile)
+}

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -32,7 +32,6 @@ func TestLogin(t *testing.T) {
 
 	mux.Handle("/login", Login(GetAuthorizationURLOptions{
 		Domain:      "lyft.com",
-		ProjectID:   "proj_123",
 		RedirectURI: redirectURI,
 	}))
 
@@ -52,7 +51,6 @@ func TestLogin(t *testing.T) {
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		p, err := GetProfile(context.Background(), GetProfileOptions{
 			Code:        "authorization_code",
-			ProjectID:   "proj_123",
 			RedirectURI: redirectURI,
 		})
 		if err != nil {
@@ -71,7 +69,7 @@ func TestLogin(t *testing.T) {
 		Endpoint:   server.URL,
 		HTTPClient: server.Client(),
 	}
-	SetAPIKey("test")
+	Init("test", "proj_123")
 
 	res, err := server.Client().Get(server.URL + "/login")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- `ProjectID` is now set at the client level
- `RedirectURI` is now set at the client level
- `DefaultClient` is now initialized with `Configure()` function

## Why this change
I noticed that both `ProjectID` and `RedirectURI` are used in `GetAuthorizationURL` and `GetProfile`:
- It is required that they match between those 2 calls
- Having them set once is less prone to human error than documenting that they must match
- Less options to think about => more simple => better dev experience when getting started