### PR TITLE
Maxchehab/ch1327/go implement idempotency key header for audit

### DIFF
--- a/pkg/auditlog/auditlog.go
+++ b/pkg/auditlog/auditlog.go
@@ -67,7 +67,7 @@ type Event struct {
 
 	// If no key is provided or the key is empty, the key will not be attached
 	// to the request.
-	IdempotencyKey string
+	IdempotencyKey string `json:"-"`
 
 	// An ip address that locates where the audit log occurred.
 	Location string `json:"location"`

--- a/pkg/auditlog/auditlog.go
+++ b/pkg/auditlog/auditlog.go
@@ -28,8 +28,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 var (
@@ -63,12 +61,13 @@ type Event struct {
 	ActorID    string     `json:"actor_id"`
 	Group      string     `json:"group"`
 
-	// A key that ensures that an same event is not processed multiple time.
+	// A key that ensures that the same event is not processed multiple times.
 	// Once the event is sent for the first time, the lock on the key expires
 	// after 24 hours.
-	//
-	// An idempotency key is automatically generated if not set.
-	IdempotencyKey string `json:"-"`
+
+	// If no key is provided or the key is empty, the key will not be attached
+	// to the request.
+	IdempotencyKey string
 
 	// An ip address that locates where the audit log occurred.
 	Location string `json:"location"`
@@ -130,11 +129,4 @@ func defaultTime(t time.Time) time.Time {
 		t = time.Now().UTC()
 	}
 	return t
-}
-
-func defaultIdempotencyKey(key string) string {
-	if key == "" {
-		return uuid.New().String()
-	}
-	return key
 }

--- a/pkg/auditlog/client.go
+++ b/pkg/auditlog/client.go
@@ -53,7 +53,6 @@ func (c *Client) Publish(ctx context.Context, e Event) error {
 		return err
 	}
 
-	e.IdempotencyKey = defaultIdempotencyKey(e.IdempotencyKey)
 	e.OccurredAt = defaultTime(e.OccurredAt)
 
 	data, err := c.JSONEncode(e)
@@ -67,8 +66,11 @@ func (c *Client) Publish(ctx context.Context, e Event) error {
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Idempotency-Key", e.IdempotencyKey)
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+
+	if len(e.IdempotencyKey) > 0 {
+		req.Header.Set("Idempotency-Key", e.IdempotencyKey)
+	}
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/pkg/auditlog/client.go
+++ b/pkg/auditlog/client.go
@@ -68,7 +68,7 @@ func (c *Client) Publish(ctx context.Context, e Event) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 
-	if len(e.IdempotencyKey) > 0 {
+	if e.IdempotencyKey != "" {
 		req.Header.Set("Idempotency-Key", e.IdempotencyKey)
 	}
 

--- a/pkg/auditlog/client_test.go
+++ b/pkg/auditlog/client_test.go
@@ -95,30 +95,18 @@ func (h *defaultTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requiredHeaders := map[string]string{
-		"Content-Type":    "application/json",
-		"Idempotency-Key": "test",
-		"Authorization":   "Bearer test",
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer test",
 	}
 
 	for k, v := range requiredHeaders {
 		val := r.Header.Get(k)
 
-		switch k {
-		case "Idempotency-Key":
-			if val == "" {
-				h.errors++
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte("no indempotency key found"))
-				return
-			}
-
-		default:
-			if val != v {
-				h.errors++
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte("bad header value for " + k))
-				return
-			}
+		if val != v {
+			h.errors++
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("bad header value for " + k))
+			return
 		}
 	}
 


### PR DESCRIPTION
This PR adjusts the idempotency key feature of the SDK so that if it is not provided by the developer, the header will not be attached to the outgoing request.

I had to remove the idempotency key as a required header within the Audit Log tests (which lowers coverage) since I was unsure how to test this change without making drastic changes to how the test suite functions. 