### PR TITLE
remove default env api key to audit log http client

### DIFF
--- a/pkg/auditlog/auditlog.go
+++ b/pkg/auditlog/auditlog.go
@@ -26,14 +26,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 )
 
 var (
 	// DefaultClient is the client used by SetAPIKey and Publish functions.
 	DefaultClient = &Client{
-		APIKey:   os.Getenv("WORKOS_API_KEY"),
 		Endpoint: "https://api.workos.com/events",
 	}
 

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -38,12 +38,15 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"os"
 )
 
 var (
 	// DefaultClient is the client used by GetAuthorizationURL, GetProfile and
 	// Login functions.
-	DefaultClient = &Client{}
+	DefaultClient = &Client{
+		APIKey: os.Getenv("WORKOS_API_KEY"),
+	}
 )
 
 // Configure configures the default client that is used by GetAuthorizationURL,

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -38,15 +38,12 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"os"
 )
 
 var (
 	// DefaultClient is the client used by GetAuthorizationURL, GetProfile and
 	// Login functions.
-	DefaultClient = &Client{
-		APIKey: os.Getenv("WORKOS_API_KEY"),
-	}
+	DefaultClient = &Client{}
 )
 
 // Configure configures the default client that is used by GetAuthorizationURL,


### PR DESCRIPTION
## summary
This PR setup the default SSO HTTP client API key to the one set in the env.