### PR TITLE
Draft connection support

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -201,7 +201,7 @@ func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profil
 // PromoteDraftConnectionOptions contains the options to pass in order to
 // promote a draft connection.
 type PromoteDraftConnectionOptions struct {
-	ID string `json:"id"`
+	Token string `json:"id"`
 }
 
 // PromoteDraftConnection promotes a draft connection created via IdP Link Embed

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -223,8 +223,9 @@ func (c *Client) PromoteDraftConnection(ctx context.Context, opts PromoteDraftCo
 		return err
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -201,6 +201,7 @@ func TestPromoteDraftConnectionUnauthorized(t *testing.T) {
 		Token: "wOrkOStoKeN",
 	})
 	require.Error(t, err)
+	t.Log(err)
 }
 
 func TestPromoteDraftBadToken(t *testing.T) {
@@ -216,6 +217,7 @@ func TestPromoteDraftBadToken(t *testing.T) {
 		Token: "wOrkOStoKeNfoo",
 	})
 	require.Error(t, err)
+	t.Log(err)
 }
 
 func promoteDraftConnectionTestHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -171,4 +172,81 @@ func profileTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	w.Write(b)
+}
+
+func TestPromoteDraftConnection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(promoteDraftConnectionTestHandler))
+	defer server.Close()
+
+	client := &Client{
+		APIKey:   "test",
+		Endpoint: server.URL,
+	}
+
+	err := client.PromoteDraftConnection(context.TODO(), PromoteDraftConnectionOptions{
+		Token: "wOrkOStoKeN",
+	})
+	require.NoError(t, err)
+}
+
+func TestPromoteDraftConnectionUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(promoteDraftConnectionTestHandler))
+	defer server.Close()
+
+	client := &Client{
+		Endpoint: server.URL,
+	}
+
+	err := client.PromoteDraftConnection(context.TODO(), PromoteDraftConnectionOptions{
+		Token: "wOrkOStoKeN",
+	})
+	require.Error(t, err)
+}
+
+func TestPromoteDraftBadToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(promoteDraftConnectionTestHandler))
+	defer server.Close()
+
+	client := &Client{
+		APIKey:   "test",
+		Endpoint: server.URL,
+	}
+
+	err := client.PromoteDraftConnection(context.TODO(), PromoteDraftConnectionOptions{
+		Token: "wOrkOStoKeNfoo",
+	})
+	require.Error(t, err)
+}
+
+func promoteDraftConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		http.Error(w, "invalid content type", http.StatusBadRequest)
+		return
+	}
+
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	userAgent := r.Header.Get("User-Agent")
+	if !strings.HasPrefix(userAgent, "workos-go/") {
+		http.Error(w, "bad user agent", http.StatusBadRequest)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if string(body) != `{"id":"wOrkOStoKeN"}` {
+		http.Error(w, "bad token", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }


### PR DESCRIPTION
## Summary
This PR adds the `PromoteDraftConnection` support (`/draft_connections/convert`) to the `sso` package.

## Link
https://app.asana.com/0/1160151042010922/1161174977831259