### PR TITLE
Create package for Directory Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 A Golang SDK to interact with [WorkOS](https://workos.com) APIs.
 
 - [AuditTrail](https://github.com/workos-inc/workos-go/tree/master/pkg/audittrail)
+- [DirectorySync](https://github.com/workos-inc/workos-go/tree/master/pkg/directorysync)
 - [SSO](https://github.com/workos-inc/workos-go/tree/master/pkg/sso)
 
 ## Install

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/audittrail/client.go
+++ b/pkg/audittrail/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/workos-inc/workos-go/internal/workos"
 )
 
-// Client represents a client that performs audittrail request to WorkOS API.
+// Client represents a client that performs audittrail requests to WorkOS API.
 type Client struct {
 	// The WorkOS api key. It can be found in
 	// https://dashboard.workos.com/api-keys.

--- a/pkg/directorysync/README.md
+++ b/pkg/directorysync/README.md
@@ -1,0 +1,35 @@
+# directorysync
+
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos-inc/workos-go/pkg/directorysync)
+
+A Go package to make requests to the WorkOS Directory Sync API.
+
+## Install
+
+```sh
+go get -u github.com/workos-inc/workos-go/pkg/directorysync
+```
+
+## How it works
+
+You first need to setup a Directory on [workos.com](https://dashboard.workos.com/directory-sync).
+
+```go
+package main
+
+import "github.com/workos-inc/workos-go/pkg/directorysync"
+
+func main() {
+  directorysync.SetAPIKey("my_api_key")
+
+  directoryUsers, err := directorysync.ListUsers(
+    context.Background(),
+    directorysync.ListUsersOpts{
+      Directory: "directory_id",
+    },
+  )
+  if err != nil {
+      // Handle error.
+  }
+}
+```

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -78,7 +78,7 @@ type ListMetadata struct {
 	// Pagination cursor to receive records before a provided ID.
 	Before string `json:"before"`
 
-	// Pagination cursor to receive records before a provided ID.
+	// Pagination cursor to receive records after a provided ID.
 	After string `json:"after"`
 }
 
@@ -316,7 +316,6 @@ func (c *Client) GetGroup(
 ) (Group, error) {
 	c.once.Do(c.init)
 
-	fmt.Printf("%+v\n", opts)
 	endpoint := fmt.Sprintf(
 		"%s/directory_groups/%s",
 		c.Endpoint,
@@ -401,7 +400,7 @@ type Directory struct {
 	State DirectoryState `json:"state"`
 }
 
-// ListDirectoriesOpts contains the options to request a project's Directories.
+// ListDirectoriesOpts contains the options to request a Project's Directories.
 type ListDirectoriesOpts struct {
 	// Domain of a Directory. Can be empty.
 	Domain string

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -40,8 +40,8 @@ func (c *Client) init() {
 	}
 }
 
-// DirectoryUserEmail contains data about a Directory User's e-mail address.
-type DirectoryUserEmail struct {
+// UserEmail contains data about a Directory User's e-mail address.
+type UserEmail struct {
 	// Flag to indicate if this e-mail is primary.
 	Primary bool
 
@@ -52,8 +52,8 @@ type DirectoryUserEmail struct {
 	Type string
 }
 
-// DirectoryUser contains data about a provisioned Directory User.
-type DirectoryUser struct {
+// User contains data about a provisioned Directory User.
+type User struct {
 	// The User's unique identifier.
 	ID string `json:"id"`
 
@@ -61,7 +61,7 @@ type DirectoryUser struct {
 	Username string `json:"username"`
 
 	// The User's e-mails.
-	Emails []DirectoryUserEmail `json:"emails"`
+	Emails []UserEmail `json:"emails"`
 
 	// The User's first name.
 	FirstName string `json:"first_name"`
@@ -104,7 +104,7 @@ type ListUsersOpts struct {
 // provisioned Directory Users.
 type ListUsersResponse struct {
 	// List of provisioned Users.
-	Data []DirectoryUser `json:"data"`
+	Data []User `json:"data"`
 
 	// Cursor pagination options.
 	ListMetadata ListMetadata `json:"listMetadata"`
@@ -164,8 +164,8 @@ func (c *Client) ListUsers(
 	return body, err
 }
 
-// DirectoryGroup contains data about a provisioned Directory Group.
-type DirectoryGroup struct {
+// Group contains data about a provisioned Directory Group.
+type Group struct {
 	// The Group's unique identifier.
 	ID string `json:"id"`
 
@@ -195,7 +195,7 @@ type ListGroupsOpts struct {
 // provisioned Directory Groups.
 type ListGroupsResponse struct {
 	// List of provisioned Users.
-	Data []DirectoryGroup `json:"data"`
+	Data []Group `json:"data"`
 
 	// Cursor pagination options.
 	ListMetadata ListMetadata `json:"listMetadata"`
@@ -265,7 +265,7 @@ type GetUserOpts struct {
 func (c *Client) GetUser(
 	ctx context.Context,
 	opts GetUserOpts,
-) (DirectoryUser, error) {
+) (User, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf(
@@ -279,7 +279,7 @@ func (c *Client) GetUser(
 		nil,
 	)
 	if err != nil {
-		return DirectoryUser{}, err
+		return User{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -289,15 +289,15 @@ func (c *Client) GetUser(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return DirectoryUser{}, err
+		return User{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return DirectoryUser{}, err
+		return User{}, err
 	}
 
-	var body DirectoryUser
+	var body User
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err
@@ -313,7 +313,7 @@ type GetGroupOpts struct {
 func (c *Client) GetGroup(
 	ctx context.Context,
 	opts GetGroupOpts,
-) (DirectoryGroup, error) {
+) (Group, error) {
 	c.once.Do(c.init)
 
 	fmt.Printf("%+v\n", opts)
@@ -328,7 +328,7 @@ func (c *Client) GetGroup(
 		nil,
 	)
 	if err != nil {
-		return DirectoryGroup{}, err
+		return Group{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -338,15 +338,15 @@ func (c *Client) GetGroup(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return DirectoryGroup{}, err
+		return Group{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return DirectoryGroup{}, err
+		return Group{}, err
 	}
 
-	var body DirectoryGroup
+	var body Group
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -1,0 +1,468 @@
+package directorysync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/workos-inc/workos-go/internal/workos"
+)
+
+// ResponseLimit is the default number of records to limit a response to.
+const ResponseLimit = 10
+
+// Client represents a client that performs Directory Sync requests to the WorkOS API.
+type Client struct {
+	// The WorkOS API Key. It can be found in https://dashboard.workos.com/api-keys.
+	APIKey string
+
+	// The http.Client that is used to get Directory Sync records from WorkOS.
+	// Defaults to http.Client.
+	HTTPClient *http.Client
+
+	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
+	Endpoint string
+
+	once sync.Once
+}
+
+func (c *Client) init() {
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	if c.Endpoint == "" {
+		c.Endpoint = "https://api.workos.com"
+	}
+}
+
+// DirectoryUserEmail contains data about a Directory User's e-mail address.
+type DirectoryUserEmail struct {
+	// Flag to indicate if this e-mail is primary.
+	Primary bool
+
+	// Directory User's e-mail.
+	Value string
+
+	// Type of e-mail (ex. work).
+	Type string
+}
+
+// DirectoryUser contains data about a provisioned Directory User.
+type DirectoryUser struct {
+	// The User's unique identifier.
+	ID string `json:"id"`
+
+	// The User's username.
+	Username string `json:"username"`
+
+	// The User's e-mails.
+	Emails []DirectoryUserEmail `json:"emails"`
+
+	// The User's first name.
+	FirstName string `json:"first_name"`
+
+	// The User's last name.
+	LastName string `json:"last_name"`
+
+	// The User's raw attributes in raw encoded JSON.
+	RawAttributes json.RawMessage `json:"raw_attributes"`
+}
+
+// ListMetadata contains pagination options for Directory records.
+type ListMetadata struct {
+	// Pagination cursor to receive records before a provided ID.
+	Before string `json:"before"`
+
+	// Pagination cursor to receive records before a provided ID.
+	After string `json:"after"`
+}
+
+// GetDirectoryUsersOpts contains the options to request provisioned Directory Users.
+type GetDirectoryUsersOpts struct {
+	// Directory Endpoint unique identifier.
+	DirectoryEndpointID string
+
+	// Maximum number of records to return.
+	Limit int
+
+	// Pagination cursor to receive records before a provided Directory Endpoint ID.
+	Before string
+
+	// Pagination cursor to receive records after a provided Directory Endpoint ID.
+	After string
+}
+
+// GetDirectoryUsersResponse describes the response structure when requesting
+// provisioned Directory Users.
+type GetDirectoryUsersResponse struct {
+	// List of provisioned Users.
+	Data []DirectoryUser `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata ListMetadata `json:"listMetadata"`
+}
+
+// GetDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
+func (c *Client) GetDirectoryUsers(
+	ctx context.Context,
+	opts GetDirectoryUsersOpts,
+) (GetDirectoryUsersResponse, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf("%s/directories/%s/users", c.Endpoint, opts.DirectoryEndpointID)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return GetDirectoryUsersResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	limit := ResponseLimit
+	if opts.Limit != 0 {
+		limit = opts.Limit
+	}
+	q := req.URL.Query()
+	q.Add("before", opts.Before)
+	q.Add("after", opts.After)
+	q.Add("limit", strconv.Itoa(limit))
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return GetDirectoryUsersResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return GetDirectoryUsersResponse{}, err
+	}
+
+	var body GetDirectoryUsersResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// DirectoryGroup contains data about a provisioned Directory Group.
+type DirectoryGroup struct {
+	// The Group's unique identifier.
+	ID string `json:"id"`
+
+	// The Group's name.
+	Name string `json:"name"`
+}
+
+// GetDirectoryGroupsOpts contains the options to request provisioned Directory Groups.
+type GetDirectoryGroupsOpts struct {
+	// Directory Endpoint unique identifier.
+	DirectoryEndpointID string
+
+	// Maximum number of records to return.
+	Limit int
+
+	// Pagination cursor to receive records before a provided Directory Endpoint ID.
+	Before string
+
+	// Pagination cursor to receive records after a provided Directory Endpoint ID.
+	After string
+}
+
+// GetDirectoryGroupsResponse describes the response structure when requesting
+// provisioned Directory Groups.
+type GetDirectoryGroupsResponse struct {
+	// List of provisioned Users.
+	Data []DirectoryGroup `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata ListMetadata `json:"listMetadata"`
+}
+
+// GetDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
+func (c *Client) GetDirectoryGroups(
+	ctx context.Context,
+	opts GetDirectoryGroupsOpts,
+) (GetDirectoryGroupsResponse, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf("%s/directories/%s/groups", c.Endpoint, opts.DirectoryEndpointID)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return GetDirectoryGroupsResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	limit := ResponseLimit
+	if opts.Limit != 0 {
+		limit = opts.Limit
+	}
+	q := req.URL.Query()
+	q.Add("before", opts.Before)
+	q.Add("after", opts.After)
+	q.Add("limit", strconv.Itoa(limit))
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return GetDirectoryGroupsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return GetDirectoryGroupsResponse{}, err
+	}
+
+	var body GetDirectoryGroupsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// GetDirectoryUserOpts contains the options to request details for a provisioned Directory User.
+type GetDirectoryUserOpts struct {
+	// Directory Endpoint unique identifier.
+	DirectoryEndpointID string
+
+	// Directory User unique identifier.
+	DirectoryUserID string
+}
+
+// GetDirectoryUser gets a provisioned User for a Directory Endpoint.
+func (c *Client) GetDirectoryUser(
+	ctx context.Context,
+	opts GetDirectoryUserOpts,
+) (DirectoryUser, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf(
+		"%s/directories/%s/users/%s",
+		c.Endpoint,
+		opts.DirectoryEndpointID,
+		opts.DirectoryUserID,
+	)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return DirectoryUser{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return DirectoryUser{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return DirectoryUser{}, err
+	}
+
+	var body DirectoryUser
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// GetDirectoryUserGroupsOpts contains the options to request details for a
+// provisioned Directory User's Groups.
+type GetDirectoryUserGroupsOpts struct {
+	// Directory Endpoint unique identifier.
+	DirectoryEndpointID string
+
+	// Directory User unique identifier.
+	DirectoryUserID string
+}
+
+// GetDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
+func (c *Client) GetDirectoryUserGroups(
+	ctx context.Context,
+	opts GetDirectoryUserGroupsOpts,
+) ([]DirectoryGroup, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf(
+		"%s/directories/%s/users/%s/groups",
+		c.Endpoint,
+		opts.DirectoryEndpointID,
+		opts.DirectoryUserID,
+	)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return []DirectoryGroup{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return []DirectoryGroup{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return []DirectoryGroup{}, err
+	}
+
+	var body []DirectoryGroup
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// DirectoryEndpointType represents a Directory type.
+type DirectoryEndpointType string
+
+// Constants that enumerate the available Directory types.
+const (
+	OktaSCIMV1_1    DirectoryEndpointType = "okta scim v1.1"
+	OktaSCIMV2_0    DirectoryEndpointType = "okta scim v2.0"
+	AzureSCIMV2_0   DirectoryEndpointType = "azure scim v2.0"
+	GSuiteDirectory DirectoryEndpointType = "gsuite directory"
+	GenericSCIMV1_1 DirectoryEndpointType = "generic scim v1.1"
+	GenericSCIMV2_0 DirectoryEndpointType = "generic scim v2.0"
+)
+
+// DirectoryEndpointState represents if a Directory is linked or unlinked.
+type DirectoryEndpointState string
+
+// Constants that enumerate the linked status of a Directory.
+const (
+	Linked   DirectoryEndpointState = "linked"
+	Unlinked DirectoryEndpointState = "unlinked"
+)
+
+// DirectoryEndpoint contains data about a project's directory.
+type DirectoryEndpoint struct {
+	// Directory Endpoint unique identifier.
+	ID string `json:"id"`
+
+	// Directory Endpoint name.
+	Name string `json:"name"`
+
+	// Directory Endpoint domain.
+	Domain string `json:"domain"`
+
+	// Externally used identifier for the Directory Endpoint.
+	ExternalKey string `json:"external_key"`
+
+	// Bearer Token used to authenticate requests.
+	BearerToken string `json:"bearer_token"`
+
+	// Identifier for the Directory Endpoint's Project.
+	ProjectID string `json:"project_id"`
+
+	// Directory Type for an Endpoint.
+	Type DirectoryEndpointType `json:"type"`
+
+	// Linked status for the Directory Endpoint.
+	State DirectoryEndpointState `json:"state"`
+}
+
+// GetDirectoriesOpts contains the options to request a project's Directories.
+type GetDirectoriesOpts struct {
+	// Domain of a Directory Endpoint. Can be empty.
+	Domain string
+
+	// Searchable text for a Directory Endpoint. Can be empty.
+	Search string
+
+	// Maximum number of records to return.
+	Limit int
+
+	// Pagination cursor to receive records before a provided Directory Endpoint ID.
+	Before string
+
+	// Pagination cursor to receive records after a provided Directory Endpoint ID.
+	After string
+}
+
+// GetDirectoriesResponse describes the response structure when requesting
+// existing directories.
+type GetDirectoriesResponse struct {
+	// List of directory endpoints.
+	Data []DirectoryEndpoint `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata ListMetadata `json:"listMetadata"`
+}
+
+// GetDirectories gets details of existing directories.
+func (c *Client) GetDirectories(
+	ctx context.Context,
+	opts GetDirectoriesOpts,
+) (GetDirectoriesResponse, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf("%s/directories", c.Endpoint)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return GetDirectoriesResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	limit := ResponseLimit
+	if opts.Limit != 0 {
+		limit = opts.Limit
+	}
+	q := req.URL.Query()
+	q.Add("before", opts.Before)
+	q.Add("after", opts.After)
+	q.Add("limit", strconv.Itoa(limit))
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return GetDirectoriesResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return GetDirectoriesResponse{}, err
+	}
+
+	var body GetDirectoriesResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -82,8 +82,8 @@ type ListMetadata struct {
 	After string `json:"after"`
 }
 
-// ListDirectoryUsersOpts contains the options to request provisioned Directory Users.
-type ListDirectoryUsersOpts struct {
+// ListUsersOpts contains the options to request provisioned Directory Users.
+type ListUsersOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -97,9 +97,9 @@ type ListDirectoryUsersOpts struct {
 	After string
 }
 
-// ListDirectoryUsersResponse describes the response structure when requesting
+// ListUsersResponse describes the response structure when requesting
 // provisioned Directory Users.
-type ListDirectoryUsersResponse struct {
+type ListUsersResponse struct {
 	// List of provisioned Users.
 	Data []DirectoryUser `json:"data"`
 
@@ -107,11 +107,11 @@ type ListDirectoryUsersResponse struct {
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// ListDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
-func (c *Client) ListDirectoryUsers(
+// ListUsers gets a list of provisioned Users for a Directory Endpoint.
+func (c *Client) ListUsers(
 	ctx context.Context,
-	opts ListDirectoryUsersOpts,
-) (ListDirectoryUsersResponse, error) {
+	opts ListUsersOpts,
+) (ListUsersResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/directories/%s/users", c.Endpoint, opts.DirectoryEndpointID)
@@ -121,7 +121,7 @@ func (c *Client) ListDirectoryUsers(
 		nil,
 	)
 	if err != nil {
-		return ListDirectoryUsersResponse{}, err
+		return ListUsersResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -141,15 +141,15 @@ func (c *Client) ListDirectoryUsers(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return ListDirectoryUsersResponse{}, err
+		return ListUsersResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return ListDirectoryUsersResponse{}, err
+		return ListUsersResponse{}, err
 	}
 
-	var body ListDirectoryUsersResponse
+	var body ListUsersResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err
@@ -164,8 +164,8 @@ type DirectoryGroup struct {
 	Name string `json:"name"`
 }
 
-// ListDirectoryGroupsOpts contains the options to request provisioned Directory Groups.
-type ListDirectoryGroupsOpts struct {
+// ListGroupsOpts contains the options to request provisioned Directory Groups.
+type ListGroupsOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -179,9 +179,9 @@ type ListDirectoryGroupsOpts struct {
 	After string
 }
 
-// ListDirectoryGroupsResponse describes the response structure when requesting
+// ListGroupsResponse describes the response structure when requesting
 // provisioned Directory Groups.
-type ListDirectoryGroupsResponse struct {
+type ListGroupsResponse struct {
 	// List of provisioned Users.
 	Data []DirectoryGroup `json:"data"`
 
@@ -189,11 +189,11 @@ type ListDirectoryGroupsResponse struct {
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// ListDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
-func (c *Client) ListDirectoryGroups(
+// ListGroups gets a list of provisioned Groups for a Directory Endpoint.
+func (c *Client) ListGroups(
 	ctx context.Context,
-	opts ListDirectoryGroupsOpts,
-) (ListDirectoryGroupsResponse, error) {
+	opts ListGroupsOpts,
+) (ListGroupsResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/directories/%s/groups", c.Endpoint, opts.DirectoryEndpointID)
@@ -203,7 +203,7 @@ func (c *Client) ListDirectoryGroups(
 		nil,
 	)
 	if err != nil {
-		return ListDirectoryGroupsResponse{}, err
+		return ListGroupsResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -223,22 +223,22 @@ func (c *Client) ListDirectoryGroups(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return ListDirectoryGroupsResponse{}, err
+		return ListGroupsResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return ListDirectoryGroupsResponse{}, err
+		return ListGroupsResponse{}, err
 	}
 
-	var body ListDirectoryGroupsResponse
+	var body ListGroupsResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err
 }
 
-// GetDirectoryUserOpts contains the options to request details for a provisioned Directory User.
-type GetDirectoryUserOpts struct {
+// GetUserOpts contains the options to request details for a provisioned Directory User.
+type GetUserOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -246,10 +246,10 @@ type GetDirectoryUserOpts struct {
 	DirectoryUserID string
 }
 
-// GetDirectoryUser gets a provisioned User for a Directory Endpoint.
-func (c *Client) GetDirectoryUser(
+// GetUser gets a provisioned User for a Directory Endpoint.
+func (c *Client) GetUser(
 	ctx context.Context,
-	opts GetDirectoryUserOpts,
+	opts GetUserOpts,
 ) (DirectoryUser, error) {
 	c.once.Do(c.init)
 
@@ -289,9 +289,9 @@ func (c *Client) GetDirectoryUser(
 	return body, err
 }
 
-// ListDirectoryUserGroupsOpts contains the options to request details for a
+// ListUserGroupsOpts contains the options to request details for a
 // provisioned Directory User's Groups.
-type ListDirectoryUserGroupsOpts struct {
+type ListUserGroupsOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -299,10 +299,10 @@ type ListDirectoryUserGroupsOpts struct {
 	DirectoryUserID string
 }
 
-// ListDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
-func (c *Client) ListDirectoryUserGroups(
+// ListUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
+func (c *Client) ListUserGroups(
 	ctx context.Context,
-	opts ListDirectoryUserGroupsOpts,
+	opts ListUserGroupsOpts,
 ) ([]DirectoryGroup, error) {
 	c.once.Do(c.init)
 

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -84,16 +84,19 @@ type ListMetadata struct {
 
 // ListUsersOpts contains the options to request provisioned Directory Users.
 type ListUsersOpts struct {
-	// Directory Endpoint unique identifier.
-	DirectoryEndpointID string
+	// Directory unique identifier.
+	Directory string
+
+	// Directory Group unique identifier.
+	Group string
 
 	// Maximum number of records to return.
 	Limit int
 
-	// Pagination cursor to receive records before a provided Directory Endpoint ID.
+	// Pagination cursor to receive records before a provided Directory ID.
 	Before string
 
-	// Pagination cursor to receive records after a provided Directory Endpoint ID.
+	// Pagination cursor to receive records after a provided Directory ID.
 	After string
 }
 
@@ -114,7 +117,7 @@ func (c *Client) ListUsers(
 ) (ListUsersResponse, error) {
 	c.once.Do(c.init)
 
-	endpoint := fmt.Sprintf("%s/directories/%s/users", c.Endpoint, opts.DirectoryEndpointID)
+	endpoint := fmt.Sprintf("%s/directory_users", c.Endpoint)
 	req, err := http.NewRequest(
 		http.MethodGet,
 		endpoint,
@@ -134,6 +137,12 @@ func (c *Client) ListUsers(
 		limit = opts.Limit
 	}
 	q := req.URL.Query()
+	if opts.Directory != "" {
+		q.Add("directory", opts.Directory)
+	}
+	if opts.Group != "" {
+		q.Add("group", opts.Group)
+	}
 	q.Add("before", opts.Before)
 	q.Add("after", opts.After)
 	q.Add("limit", strconv.Itoa(limit))
@@ -166,16 +175,19 @@ type DirectoryGroup struct {
 
 // ListGroupsOpts contains the options to request provisioned Directory Groups.
 type ListGroupsOpts struct {
-	// Directory Endpoint unique identifier.
-	DirectoryEndpointID string
+	// Directory unique identifier.
+	Directory string
+
+	// Directory User unique identifier.
+	User string
 
 	// Maximum number of records to return.
 	Limit int
 
-	// Pagination cursor to receive records before a provided Directory Endpoint ID.
+	// Pagination cursor to receive records before a provided Directory ID.
 	Before string
 
-	// Pagination cursor to receive records after a provided Directory Endpoint ID.
+	// Pagination cursor to receive records after a provided Directory ID.
 	After string
 }
 
@@ -196,7 +208,7 @@ func (c *Client) ListGroups(
 ) (ListGroupsResponse, error) {
 	c.once.Do(c.init)
 
-	endpoint := fmt.Sprintf("%s/directories/%s/groups", c.Endpoint, opts.DirectoryEndpointID)
+	endpoint := fmt.Sprintf("%s/directory_groups", c.Endpoint)
 	req, err := http.NewRequest(
 		http.MethodGet,
 		endpoint,
@@ -216,6 +228,12 @@ func (c *Client) ListGroups(
 		limit = opts.Limit
 	}
 	q := req.URL.Query()
+	if opts.Directory != "" {
+		q.Add("directory", opts.Directory)
+	}
+	if opts.User != "" {
+		q.Add("user", opts.User)
+	}
 	q.Add("before", opts.Before)
 	q.Add("after", opts.After)
 	q.Add("limit", strconv.Itoa(limit))
@@ -239,11 +257,8 @@ func (c *Client) ListGroups(
 
 // GetUserOpts contains the options to request details for a provisioned Directory User.
 type GetUserOpts struct {
-	// Directory Endpoint unique identifier.
-	DirectoryEndpointID string
-
 	// Directory User unique identifier.
-	DirectoryUserID string
+	User string
 }
 
 // GetUser gets a provisioned User for a Directory Endpoint.
@@ -254,10 +269,9 @@ func (c *Client) GetUser(
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf(
-		"%s/directories/%s/users/%s",
+		"%s/directory_users/%s",
 		c.Endpoint,
-		opts.DirectoryEndpointID,
-		opts.DirectoryUserID,
+		opts.User,
 	)
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -289,28 +303,24 @@ func (c *Client) GetUser(
 	return body, err
 }
 
-// ListUserGroupsOpts contains the options to request details for a
-// provisioned Directory User's Groups.
-type ListUserGroupsOpts struct {
-	// Directory Endpoint unique identifier.
-	DirectoryEndpointID string
-
-	// Directory User unique identifier.
-	DirectoryUserID string
+// GetGroupOpts contains the options to request details for a provisioned Directory Group.
+type GetGroupOpts struct {
+	// Directory Group unique identifier.
+	Group string
 }
 
-// ListUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
-func (c *Client) ListUserGroups(
+// GetGroup gets a provisioned Group for a Directory Endpoint.
+func (c *Client) GetGroup(
 	ctx context.Context,
-	opts ListUserGroupsOpts,
-) ([]DirectoryGroup, error) {
+	opts GetGroupOpts,
+) (DirectoryGroup, error) {
 	c.once.Do(c.init)
 
+	fmt.Printf("%+v\n", opts)
 	endpoint := fmt.Sprintf(
-		"%s/directories/%s/users/%s/groups",
+		"%s/directory_groups/%s",
 		c.Endpoint,
-		opts.DirectoryEndpointID,
-		opts.DirectoryUserID,
+		opts.Group,
 	)
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -318,7 +328,7 @@ func (c *Client) ListUserGroups(
 		nil,
 	)
 	if err != nil {
-		return []DirectoryGroup{}, err
+		return DirectoryGroup{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -328,98 +338,98 @@ func (c *Client) ListUserGroups(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return []DirectoryGroup{}, err
+		return DirectoryGroup{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return []DirectoryGroup{}, err
+		return DirectoryGroup{}, err
 	}
 
-	var body []DirectoryGroup
+	var body DirectoryGroup
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err
 }
 
-// DirectoryEndpointType represents a Directory type.
-type DirectoryEndpointType string
+// DirectoryType represents a Directory type.
+type DirectoryType string
 
 // Constants that enumerate the available Directory types.
 const (
-	OktaSCIMV1_1    DirectoryEndpointType = "okta scim v1.1"
-	OktaSCIMV2_0    DirectoryEndpointType = "okta scim v2.0"
-	AzureSCIMV2_0   DirectoryEndpointType = "azure scim v2.0"
-	GSuiteDirectory DirectoryEndpointType = "gsuite directory"
-	GenericSCIMV1_1 DirectoryEndpointType = "generic scim v1.1"
-	GenericSCIMV2_0 DirectoryEndpointType = "generic scim v2.0"
+	OktaSCIMV1_1    DirectoryType = "okta scim v1.1"
+	OktaSCIMV2_0    DirectoryType = "okta scim v2.0"
+	AzureSCIMV2_0   DirectoryType = "azure scim v2.0"
+	GSuiteDirectory DirectoryType = "gsuite directory"
+	GenericSCIMV1_1 DirectoryType = "generic scim v1.1"
+	GenericSCIMV2_0 DirectoryType = "generic scim v2.0"
 )
 
-// DirectoryEndpointState represents if a Directory is linked or unlinked.
-type DirectoryEndpointState string
+// DirectoryState represents if a Directory is linked or unlinked.
+type DirectoryState string
 
 // Constants that enumerate the linked status of a Directory.
 const (
-	Linked   DirectoryEndpointState = "linked"
-	Unlinked DirectoryEndpointState = "unlinked"
+	Linked   DirectoryState = "linked"
+	Unlinked DirectoryState = "unlinked"
 )
 
-// DirectoryEndpoint contains data about a project's directory.
-type DirectoryEndpoint struct {
-	// Directory Endpoint unique identifier.
+// Directory contains data about a project's directory.
+type Directory struct {
+	// Directory unique identifier.
 	ID string `json:"id"`
 
-	// Directory Endpoint name.
+	// Directory name.
 	Name string `json:"name"`
 
-	// Directory Endpoint domain.
+	// Directory domain.
 	Domain string `json:"domain"`
 
-	// Externally used identifier for the Directory Endpoint.
+	// Externally used identifier for the Directory.
 	ExternalKey string `json:"external_key"`
 
 	// Bearer Token used to authenticate requests.
 	BearerToken string `json:"bearer_token"`
 
-	// Identifier for the Directory Endpoint's Project.
+	// Identifier for the Directory's Project.
 	ProjectID string `json:"project_id"`
 
-	// Directory Type for an Endpoint.
-	Type DirectoryEndpointType `json:"type"`
+	// Type of the directory.
+	Type DirectoryType `json:"type"`
 
-	// Linked status for the Directory Endpoint.
-	State DirectoryEndpointState `json:"state"`
+	// Linked status for the Directory.
+	State DirectoryState `json:"state"`
 }
 
 // ListDirectoriesOpts contains the options to request a project's Directories.
 type ListDirectoriesOpts struct {
-	// Domain of a Directory Endpoint. Can be empty.
+	// Domain of a Directory. Can be empty.
 	Domain string
 
-	// Searchable text for a Directory Endpoint. Can be empty.
+	// Searchable text for a Directory. Can be empty.
 	Search string
 
 	// Maximum number of records to return.
 	Limit int
 
-	// Pagination cursor to receive records before a provided Directory Endpoint ID.
+	// Pagination cursor to receive records before a provided Directory ID.
 	Before string
 
-	// Pagination cursor to receive records after a provided Directory Endpoint ID.
+	// Pagination cursor to receive records after a provided Directory ID.
 	After string
 }
 
 // ListDirectoriesResponse describes the response structure when requesting
-// existing directories.
+// existing Directories.
 type ListDirectoriesResponse struct {
-	// List of directory endpoints.
-	Data []DirectoryEndpoint `json:"data"`
+	// List of Directories.
+	Data []Directory `json:"data"`
 
 	// Cursor pagination options.
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// ListDirectories gets details of existing directories.
+// ListDirectories gets details of existing Directories.
 func (c *Client) ListDirectories(
 	ctx context.Context,
 	opts ListDirectoriesOpts,

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -110,7 +110,7 @@ type ListUsersResponse struct {
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// ListUsers gets a list of provisioned Users for a Directory Endpoint.
+// ListUsers gets a list of provisioned Users for a Directory.
 func (c *Client) ListUsers(
 	ctx context.Context,
 	opts ListUsersOpts,
@@ -309,7 +309,7 @@ type GetGroupOpts struct {
 	Group string
 }
 
-// GetGroup gets a provisioned Group for a Directory Endpoint.
+// GetGroup gets a provisioned Group for a Directory.
 func (c *Client) GetGroup(
 	ctx context.Context,
 	opts GetGroupOpts,

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -82,8 +82,8 @@ type ListMetadata struct {
 	After string `json:"after"`
 }
 
-// GetDirectoryUsersOpts contains the options to request provisioned Directory Users.
-type GetDirectoryUsersOpts struct {
+// ListDirectoryUsersOpts contains the options to request provisioned Directory Users.
+type ListDirectoryUsersOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -97,9 +97,9 @@ type GetDirectoryUsersOpts struct {
 	After string
 }
 
-// GetDirectoryUsersResponse describes the response structure when requesting
+// ListDirectoryUsersResponse describes the response structure when requesting
 // provisioned Directory Users.
-type GetDirectoryUsersResponse struct {
+type ListDirectoryUsersResponse struct {
 	// List of provisioned Users.
 	Data []DirectoryUser `json:"data"`
 
@@ -107,11 +107,11 @@ type GetDirectoryUsersResponse struct {
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// GetDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
-func (c *Client) GetDirectoryUsers(
+// ListDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
+func (c *Client) ListDirectoryUsers(
 	ctx context.Context,
-	opts GetDirectoryUsersOpts,
-) (GetDirectoryUsersResponse, error) {
+	opts ListDirectoryUsersOpts,
+) (ListDirectoryUsersResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/directories/%s/users", c.Endpoint, opts.DirectoryEndpointID)
@@ -121,7 +121,7 @@ func (c *Client) GetDirectoryUsers(
 		nil,
 	)
 	if err != nil {
-		return GetDirectoryUsersResponse{}, err
+		return ListDirectoryUsersResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -141,15 +141,15 @@ func (c *Client) GetDirectoryUsers(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return GetDirectoryUsersResponse{}, err
+		return ListDirectoryUsersResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return GetDirectoryUsersResponse{}, err
+		return ListDirectoryUsersResponse{}, err
 	}
 
-	var body GetDirectoryUsersResponse
+	var body ListDirectoryUsersResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err
@@ -164,8 +164,8 @@ type DirectoryGroup struct {
 	Name string `json:"name"`
 }
 
-// GetDirectoryGroupsOpts contains the options to request provisioned Directory Groups.
-type GetDirectoryGroupsOpts struct {
+// ListDirectoryGroupsOpts contains the options to request provisioned Directory Groups.
+type ListDirectoryGroupsOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -179,9 +179,9 @@ type GetDirectoryGroupsOpts struct {
 	After string
 }
 
-// GetDirectoryGroupsResponse describes the response structure when requesting
+// ListDirectoryGroupsResponse describes the response structure when requesting
 // provisioned Directory Groups.
-type GetDirectoryGroupsResponse struct {
+type ListDirectoryGroupsResponse struct {
 	// List of provisioned Users.
 	Data []DirectoryGroup `json:"data"`
 
@@ -189,11 +189,11 @@ type GetDirectoryGroupsResponse struct {
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// GetDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
-func (c *Client) GetDirectoryGroups(
+// ListDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
+func (c *Client) ListDirectoryGroups(
 	ctx context.Context,
-	opts GetDirectoryGroupsOpts,
-) (GetDirectoryGroupsResponse, error) {
+	opts ListDirectoryGroupsOpts,
+) (ListDirectoryGroupsResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/directories/%s/groups", c.Endpoint, opts.DirectoryEndpointID)
@@ -203,7 +203,7 @@ func (c *Client) GetDirectoryGroups(
 		nil,
 	)
 	if err != nil {
-		return GetDirectoryGroupsResponse{}, err
+		return ListDirectoryGroupsResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -223,15 +223,15 @@ func (c *Client) GetDirectoryGroups(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return GetDirectoryGroupsResponse{}, err
+		return ListDirectoryGroupsResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return GetDirectoryGroupsResponse{}, err
+		return ListDirectoryGroupsResponse{}, err
 	}
 
-	var body GetDirectoryGroupsResponse
+	var body ListDirectoryGroupsResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err
@@ -289,9 +289,9 @@ func (c *Client) GetDirectoryUser(
 	return body, err
 }
 
-// GetDirectoryUserGroupsOpts contains the options to request details for a
+// ListDirectoryUserGroupsOpts contains the options to request details for a
 // provisioned Directory User's Groups.
-type GetDirectoryUserGroupsOpts struct {
+type ListDirectoryUserGroupsOpts struct {
 	// Directory Endpoint unique identifier.
 	DirectoryEndpointID string
 
@@ -299,10 +299,10 @@ type GetDirectoryUserGroupsOpts struct {
 	DirectoryUserID string
 }
 
-// GetDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
-func (c *Client) GetDirectoryUserGroups(
+// ListDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
+func (c *Client) ListDirectoryUserGroups(
 	ctx context.Context,
-	opts GetDirectoryUserGroupsOpts,
+	opts ListDirectoryUserGroupsOpts,
 ) ([]DirectoryGroup, error) {
 	c.once.Do(c.init)
 
@@ -391,8 +391,8 @@ type DirectoryEndpoint struct {
 	State DirectoryEndpointState `json:"state"`
 }
 
-// GetDirectoriesOpts contains the options to request a project's Directories.
-type GetDirectoriesOpts struct {
+// ListDirectoriesOpts contains the options to request a project's Directories.
+type ListDirectoriesOpts struct {
 	// Domain of a Directory Endpoint. Can be empty.
 	Domain string
 
@@ -409,9 +409,9 @@ type GetDirectoriesOpts struct {
 	After string
 }
 
-// GetDirectoriesResponse describes the response structure when requesting
+// ListDirectoriesResponse describes the response structure when requesting
 // existing directories.
-type GetDirectoriesResponse struct {
+type ListDirectoriesResponse struct {
 	// List of directory endpoints.
 	Data []DirectoryEndpoint `json:"data"`
 
@@ -419,11 +419,11 @@ type GetDirectoriesResponse struct {
 	ListMetadata ListMetadata `json:"listMetadata"`
 }
 
-// GetDirectories gets details of existing directories.
-func (c *Client) GetDirectories(
+// ListDirectories gets details of existing directories.
+func (c *Client) ListDirectories(
 	ctx context.Context,
-	opts GetDirectoriesOpts,
-) (GetDirectoriesResponse, error) {
+	opts ListDirectoriesOpts,
+) (ListDirectoriesResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/directories", c.Endpoint)
@@ -433,7 +433,7 @@ func (c *Client) GetDirectories(
 		nil,
 	)
 	if err != nil {
-		return GetDirectoriesResponse{}, err
+		return ListDirectoriesResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -453,15 +453,15 @@ func (c *Client) GetDirectories(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return GetDirectoriesResponse{}, err
+		return ListDirectoriesResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos.TryGetHTTPError(res); err != nil {
-		return GetDirectoriesResponse{}, err
+		return ListDirectoriesResponse{}, err
 	}
 
-	var body GetDirectoriesResponse
+	var body ListDirectoriesResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -409,7 +409,7 @@ func TestGetDirectories(t *testing.T) {
 					DirectoryEndpoint{
 						ID:          "directory_edp_id",
 						Name:        "Ri Jeong Hyeok",
-						Domain:      "crashlanding@you.com",
+						Domain:      "crashlandingyou.com",
 						ExternalKey: "fried_chicken",
 						State:       "linked",
 						Type:        "gsuite directory",
@@ -461,7 +461,7 @@ func getDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
 			DirectoryEndpoint{
 				ID:          "directory_edp_id",
 				Name:        "Ri Jeong Hyeok",
-				Domain:      "crashlanding@you.com",
+				Domain:      "crashlandingyou.com",
 				ExternalKey: "fried_chicken",
 				State:       "linked",
 				Type:        "gsuite directory",

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestListDirectoryUsers(t *testing.T) {
+func TestListUsers(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  ListDirectoryUsersOpts
-		expected ListDirectoryUsersResponse
+		options  ListUsersOpts
+		expected ListUsersResponse
 		err      bool
 	}{
 		{
@@ -29,10 +29,10 @@ func TestListDirectoryUsers(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: ListDirectoryUsersOpts{
+			options: ListUsersOpts{
 				DirectoryEndpointID: "directory_edp_test",
 			},
-			expected: ListDirectoryUsersResponse{
+			expected: ListUsersResponse{
 				Data: []DirectoryUser{
 					DirectoryUser{
 						ID:        "directory_usr_id",
@@ -58,14 +58,14 @@ func TestListDirectoryUsers(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(listDirectoryUsersTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.ListDirectoryUsers(context.Background(), test.options)
+			directoryUsers, err := client.ListUsers(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -76,7 +76,7 @@ func TestListDirectoryUsers(t *testing.T) {
 	}
 }
 
-func listDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
+func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -89,9 +89,9 @@ func listDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(struct {
-		ListDirectoryUsersResponse
+		ListUsersResponse
 	}{
-		ListDirectoryUsersResponse: ListDirectoryUsersResponse{
+		ListUsersResponse: ListUsersResponse{
 			Data: []DirectoryUser{
 				DirectoryUser{
 					ID:        "directory_usr_id",
@@ -122,12 +122,12 @@ func listDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestListDirectoryGroups(t *testing.T) {
+func TestListGroups(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  ListDirectoryGroupsOpts
-		expected ListDirectoryGroupsResponse
+		options  ListGroupsOpts
+		expected ListGroupsResponse
 		err      bool
 	}{
 		{
@@ -140,10 +140,10 @@ func TestListDirectoryGroups(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: ListDirectoryGroupsOpts{
+			options: ListGroupsOpts{
 				DirectoryEndpointID: "directory_edp_test",
 			},
-			expected: ListDirectoryGroupsResponse{
+			expected: ListGroupsResponse{
 				Data: []DirectoryGroup{
 					DirectoryGroup{
 						ID:   "directory_grp_id",
@@ -160,14 +160,14 @@ func TestListDirectoryGroups(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(listDirectoryGroupsTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listGroupsTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.ListDirectoryGroups(context.Background(), test.options)
+			directoryUsers, err := client.ListGroups(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -178,7 +178,7 @@ func TestListDirectoryGroups(t *testing.T) {
 	}
 }
 
-func listDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+func listGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -191,9 +191,9 @@ func listDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(struct {
-		ListDirectoryGroupsResponse
+		ListGroupsResponse
 	}{
-		ListDirectoryGroupsResponse: ListDirectoryGroupsResponse{
+		ListGroupsResponse: ListGroupsResponse{
 			Data: []DirectoryGroup{
 				DirectoryGroup{
 					ID:   "directory_grp_id",
@@ -215,11 +215,11 @@ func listDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestGetDirectoryUser(t *testing.T) {
+func TestGetUser(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetDirectoryUserOpts
+		options  GetUserOpts
 		expected DirectoryUser
 		err      bool
 	}{
@@ -233,7 +233,7 @@ func TestGetDirectoryUser(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetDirectoryUserOpts{
+			options: GetUserOpts{
 				DirectoryEndpointID: "directory_edp_id",
 				DirectoryUserID:     "directory_usr_id",
 			},
@@ -255,14 +255,14 @@ func TestGetDirectoryUser(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(getDirectoryUserTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(getUserTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.GetDirectoryUser(context.Background(), test.options)
+			directoryUsers, err := client.GetUser(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -273,7 +273,7 @@ func TestGetDirectoryUser(t *testing.T) {
 	}
 }
 
-func getDirectoryUserTestHandler(w http.ResponseWriter, r *http.Request) {
+func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -307,11 +307,11 @@ func getDirectoryUserTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestListDirectoryUserGroups(t *testing.T) {
+func TestListUserGroups(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  ListDirectoryUserGroupsOpts
+		options  ListUserGroupsOpts
 		expected []DirectoryGroup
 		err      bool
 	}{
@@ -325,7 +325,7 @@ func TestListDirectoryUserGroups(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: ListDirectoryUserGroupsOpts{
+			options: ListUserGroupsOpts{
 				DirectoryEndpointID: "directory_edp_id",
 				DirectoryUserID:     "directory_usr_id",
 			},
@@ -340,14 +340,14 @@ func TestListDirectoryUserGroups(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(listDirectoryUserGroupsTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listUserGroupsTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.ListDirectoryUserGroups(context.Background(), test.options)
+			directoryUsers, err := client.ListUserGroups(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -358,7 +358,7 @@ func TestListDirectoryUserGroups(t *testing.T) {
 	}
 }
 
-func listDirectoryUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+func listUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -33,13 +33,13 @@ func TestListUsers(t *testing.T) {
 				Directory: "directory_test",
 			},
 			expected: ListUsersResponse{
-				Data: []DirectoryUser{
-					DirectoryUser{
+				Data: []User{
+					User{
 						ID:        "directory_usr_id",
 						FirstName: "Rick",
 						LastName:  "Sanchez",
-						Emails: []DirectoryUserEmail{
-							DirectoryUserEmail{
+						Emails: []UserEmail{
+							UserEmail{
 								Primary: true,
 								Type:    "work",
 								Value:   "rick@sanchez.com",
@@ -92,13 +92,13 @@ func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListUsersResponse
 	}{
 		ListUsersResponse: ListUsersResponse{
-			Data: []DirectoryUser{
-				DirectoryUser{
+			Data: []User{
+				User{
 					ID:        "directory_usr_id",
 					FirstName: "Rick",
 					LastName:  "Sanchez",
-					Emails: []DirectoryUserEmail{
-						DirectoryUserEmail{
+					Emails: []UserEmail{
+						UserEmail{
 							Primary: true,
 							Type:    "work",
 							Value:   "rick@sanchez.com",
@@ -144,8 +144,8 @@ func TestListGroups(t *testing.T) {
 				Directory: "directory_test",
 			},
 			expected: ListGroupsResponse{
-				Data: []DirectoryGroup{
-					DirectoryGroup{
+				Data: []Group{
+					Group{
 						ID:   "directory_grp_id",
 						Name: "Scientists",
 					},
@@ -194,8 +194,8 @@ func listGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListGroupsResponse
 	}{
 		ListGroupsResponse: ListGroupsResponse{
-			Data: []DirectoryGroup{
-				DirectoryGroup{
+			Data: []Group{
+				Group{
 					ID:   "directory_grp_id",
 					Name: "Scientists",
 				},
@@ -220,7 +220,7 @@ func TestGetUser(t *testing.T) {
 		scenario string
 		client   *Client
 		options  GetUserOpts
-		expected DirectoryUser
+		expected User
 		err      bool
 	}{
 		{
@@ -236,12 +236,12 @@ func TestGetUser(t *testing.T) {
 			options: GetUserOpts{
 				User: "directory_usr_id",
 			},
-			expected: DirectoryUser{
+			expected: User{
 				ID:        "directory_usr_id",
 				FirstName: "Rick",
 				LastName:  "Sanchez",
-				Emails: []DirectoryUserEmail{
-					DirectoryUserEmail{
+				Emails: []UserEmail{
+					UserEmail{
 						Primary: true,
 						Type:    "work",
 						Value:   "rick@sanchez.com",
@@ -284,12 +284,12 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(DirectoryUser{
+	body, err := json.Marshal(User{
 		ID:        "directory_usr_id",
 		FirstName: "Rick",
 		LastName:  "Sanchez",
-		Emails: []DirectoryUserEmail{
-			DirectoryUserEmail{
+		Emails: []UserEmail{
+			UserEmail{
 				Primary: true,
 				Type:    "work",
 				Value:   "rick@sanchez.com",
@@ -311,7 +311,7 @@ func TestGetGroup(t *testing.T) {
 		scenario string
 		client   *Client
 		options  GetGroupOpts
-		expected DirectoryGroup
+		expected Group
 		err      bool
 	}{
 		{
@@ -327,7 +327,7 @@ func TestGetGroup(t *testing.T) {
 			options: GetGroupOpts{
 				Group: "directory_grp_id",
 			},
-			expected: DirectoryGroup{
+			expected: Group{
 				ID:   "directory_grp_id",
 				Name: "Scientists",
 			},
@@ -366,7 +366,7 @@ func getGroupTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(DirectoryGroup{
+	body, err := json.Marshal(Group{
 		ID:   "directory_grp_id",
 		Name: "Scientists",
 	})

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -1,0 +1,483 @@
+package directorysync
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDirectoryUsers(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetDirectoryUsersOpts
+		expected GetDirectoryUsersResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Directory Users",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetDirectoryUsersOpts{
+				DirectoryEndpointID: "directory_edp_test",
+			},
+			expected: GetDirectoryUsersResponse{
+				Data: []DirectoryUser{
+					DirectoryUser{
+						ID:        "directory_usr_id",
+						FirstName: "Rick",
+						LastName:  "Sanchez",
+						Emails: []DirectoryUserEmail{
+							DirectoryUserEmail{
+								Primary: true,
+								Type:    "work",
+								Value:   "rick@sanchez.com",
+							},
+						},
+						RawAttributes: json.RawMessage(`{"foo":"bar"}`),
+					},
+				},
+				ListMetadata: ListMetadata{
+					Before: "",
+					After:  "",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getDirectoryUsersTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			directoryUsers, err := client.GetDirectoryUsers(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, directoryUsers)
+		})
+	}
+}
+
+func getDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(struct {
+		GetDirectoryUsersResponse
+	}{
+		GetDirectoryUsersResponse: GetDirectoryUsersResponse{
+			Data: []DirectoryUser{
+				DirectoryUser{
+					ID:        "directory_usr_id",
+					FirstName: "Rick",
+					LastName:  "Sanchez",
+					Emails: []DirectoryUserEmail{
+						DirectoryUserEmail{
+							Primary: true,
+							Type:    "work",
+							Value:   "rick@sanchez.com",
+						},
+					},
+					RawAttributes: json.RawMessage(`{"foo":"bar"}`),
+				},
+			},
+			ListMetadata: ListMetadata{
+				Before: "",
+				After:  "",
+			},
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestGetDirectoryGroups(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetDirectoryGroupsOpts
+		expected GetDirectoryGroupsResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Directory Groups",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetDirectoryGroupsOpts{
+				DirectoryEndpointID: "directory_edp_test",
+			},
+			expected: GetDirectoryGroupsResponse{
+				Data: []DirectoryGroup{
+					DirectoryGroup{
+						ID:   "directory_grp_id",
+						Name: "Scientists",
+					},
+				},
+				ListMetadata: ListMetadata{
+					Before: "",
+					After:  "",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getDirectoryGroupsTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			directoryUsers, err := client.GetDirectoryGroups(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, directoryUsers)
+		})
+	}
+}
+
+func getDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(struct {
+		GetDirectoryGroupsResponse
+	}{
+		GetDirectoryGroupsResponse: GetDirectoryGroupsResponse{
+			Data: []DirectoryGroup{
+				DirectoryGroup{
+					ID:   "directory_grp_id",
+					Name: "Scientists",
+				},
+			},
+			ListMetadata: ListMetadata{
+				Before: "",
+				After:  "",
+			},
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestGetDirectoryUser(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetDirectoryUserOpts
+		expected DirectoryUser
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Directory User",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetDirectoryUserOpts{
+				DirectoryEndpointID: "directory_edp_id",
+				DirectoryUserID:     "directory_usr_id",
+			},
+			expected: DirectoryUser{
+				ID:        "directory_usr_id",
+				FirstName: "Rick",
+				LastName:  "Sanchez",
+				Emails: []DirectoryUserEmail{
+					DirectoryUserEmail{
+						Primary: true,
+						Type:    "work",
+						Value:   "rick@sanchez.com",
+					},
+				},
+				RawAttributes: json.RawMessage(`{"foo":"bar"}`),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getDirectoryUserTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			directoryUsers, err := client.GetDirectoryUser(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, directoryUsers)
+		})
+	}
+}
+
+func getDirectoryUserTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(DirectoryUser{
+		ID:        "directory_usr_id",
+		FirstName: "Rick",
+		LastName:  "Sanchez",
+		Emails: []DirectoryUserEmail{
+			DirectoryUserEmail{
+				Primary: true,
+				Type:    "work",
+				Value:   "rick@sanchez.com",
+			},
+		},
+		RawAttributes: json.RawMessage(`{"foo":"bar"}`),
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestGetDirectoryUserGroups(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetDirectoryUserGroupsOpts
+		expected []DirectoryGroup
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Directory User's Groups",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetDirectoryUserGroupsOpts{
+				DirectoryEndpointID: "directory_edp_id",
+				DirectoryUserID:     "directory_usr_id",
+			},
+			expected: []DirectoryGroup{
+				DirectoryGroup{
+					ID:   "directory_grp_id",
+					Name: "Scientists",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getDirectoryUserGroupsTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			directoryUsers, err := client.GetDirectoryUserGroups(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, directoryUsers)
+		})
+	}
+}
+
+func getDirectoryUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal([]DirectoryGroup{
+		DirectoryGroup{
+			ID:   "directory_grp_id",
+			Name: "Scientists",
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestGetDirectories(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetDirectoriesOpts
+		expected GetDirectoriesResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Directories",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetDirectoriesOpts{},
+			expected: GetDirectoriesResponse{
+				Data: []DirectoryEndpoint{
+					DirectoryEndpoint{
+						ID:          "directory_edp_id",
+						Name:        "Ri Jeong Hyeok",
+						Domain:      "crashlanding@you.com",
+						ExternalKey: "fried_chicken",
+						State:       "linked",
+						Type:        "gsuite directory",
+						ProjectID:   "project_id",
+					},
+				},
+				ListMetadata: ListMetadata{
+					Before: "",
+					After:  "",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getDirectoriesTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			directoryUsers, err := client.GetDirectories(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, directoryUsers)
+		})
+	}
+}
+
+func getDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(GetDirectoriesResponse{
+		Data: []DirectoryEndpoint{
+			DirectoryEndpoint{
+				ID:          "directory_edp_id",
+				Name:        "Ri Jeong Hyeok",
+				Domain:      "crashlanding@you.com",
+				ExternalKey: "fried_chicken",
+				State:       "linked",
+				Type:        "gsuite directory",
+				ProjectID:   "project_id",
+			},
+		},
+		ListMetadata: ListMetadata{
+			Before: "",
+			After:  "",
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -30,7 +30,7 @@ func TestListUsers(t *testing.T) {
 				APIKey: "test",
 			},
 			options: ListUsersOpts{
-				DirectoryEndpointID: "directory_edp_test",
+				Directory: "directory_test",
 			},
 			expected: ListUsersResponse{
 				Data: []DirectoryUser{
@@ -141,7 +141,7 @@ func TestListGroups(t *testing.T) {
 				APIKey: "test",
 			},
 			options: ListGroupsOpts{
-				DirectoryEndpointID: "directory_edp_test",
+				Directory: "directory_test",
 			},
 			expected: ListGroupsResponse{
 				Data: []DirectoryGroup{
@@ -167,13 +167,13 @@ func TestListGroups(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.ListGroups(context.Background(), test.options)
+			directoryGroups, err := client.ListGroups(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.expected, directoryUsers)
+			require.Equal(t, test.expected, directoryGroups)
 		})
 	}
 }
@@ -234,8 +234,7 @@ func TestGetUser(t *testing.T) {
 				APIKey: "test",
 			},
 			options: GetUserOpts{
-				DirectoryEndpointID: "directory_edp_id",
-				DirectoryUserID:     "directory_usr_id",
+				User: "directory_usr_id",
 			},
 			expected: DirectoryUser{
 				ID:        "directory_usr_id",
@@ -262,13 +261,13 @@ func TestGetUser(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.GetUser(context.Background(), test.options)
+			directoryUser, err := client.GetUser(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.expected, directoryUsers)
+			require.Equal(t, test.expected, directoryUser)
 		})
 	}
 }
@@ -307,12 +306,12 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestListUserGroups(t *testing.T) {
+func TestGetGroup(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  ListUserGroupsOpts
-		expected []DirectoryGroup
+		options  GetGroupOpts
+		expected DirectoryGroup
 		err      bool
 	}{
 		{
@@ -321,44 +320,41 @@ func TestListUserGroups(t *testing.T) {
 			err:      true,
 		},
 		{
-			scenario: "Request returns Directory User's Groups",
+			scenario: "Request returns Directory Group",
 			client: &Client{
 				APIKey: "test",
 			},
-			options: ListUserGroupsOpts{
-				DirectoryEndpointID: "directory_edp_id",
-				DirectoryUserID:     "directory_usr_id",
+			options: GetGroupOpts{
+				Group: "directory_grp_id",
 			},
-			expected: []DirectoryGroup{
-				DirectoryGroup{
-					ID:   "directory_grp_id",
-					Name: "Scientists",
-				},
+			expected: DirectoryGroup{
+				ID:   "directory_grp_id",
+				Name: "Scientists",
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(listUserGroupsTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(getGroupTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.ListUserGroups(context.Background(), test.options)
+			directoryGroup, err := client.GetGroup(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.expected, directoryUsers)
+			require.Equal(t, test.expected, directoryGroup)
 		})
 	}
 }
 
-func listUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+func getGroupTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -370,11 +366,9 @@ func listUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal([]DirectoryGroup{
-		DirectoryGroup{
-			ID:   "directory_grp_id",
-			Name: "Scientists",
-		},
+	body, err := json.Marshal(DirectoryGroup{
+		ID:   "directory_grp_id",
+		Name: "Scientists",
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -405,9 +399,9 @@ func TestListDirectories(t *testing.T) {
 			},
 			options: ListDirectoriesOpts{},
 			expected: ListDirectoriesResponse{
-				Data: []DirectoryEndpoint{
-					DirectoryEndpoint{
-						ID:          "directory_edp_id",
+				Data: []Directory{
+					Directory{
+						ID:          "directory_id",
 						Name:        "Ri Jeong Hyeok",
 						Domain:      "crashlandingyou.com",
 						ExternalKey: "fried_chicken",
@@ -433,13 +427,13 @@ func TestListDirectories(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.ListDirectories(context.Background(), test.options)
+			directories, err := client.ListDirectories(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.expected, directoryUsers)
+			require.Equal(t, test.expected, directories)
 		})
 	}
 }
@@ -457,9 +451,9 @@ func listDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(ListDirectoriesResponse{
-		Data: []DirectoryEndpoint{
-			DirectoryEndpoint{
-				ID:          "directory_edp_id",
+		Data: []Directory{
+			Directory{
+				ID:          "directory_id",
 				Name:        "Ri Jeong Hyeok",
 				Domain:      "crashlandingyou.com",
 				ExternalKey: "fried_chicken",

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetDirectoryUsers(t *testing.T) {
+func TestListDirectoryUsers(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetDirectoryUsersOpts
-		expected GetDirectoryUsersResponse
+		options  ListDirectoryUsersOpts
+		expected ListDirectoryUsersResponse
 		err      bool
 	}{
 		{
@@ -29,10 +29,10 @@ func TestGetDirectoryUsers(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetDirectoryUsersOpts{
+			options: ListDirectoryUsersOpts{
 				DirectoryEndpointID: "directory_edp_test",
 			},
-			expected: GetDirectoryUsersResponse{
+			expected: ListDirectoryUsersResponse{
 				Data: []DirectoryUser{
 					DirectoryUser{
 						ID:        "directory_usr_id",
@@ -58,14 +58,14 @@ func TestGetDirectoryUsers(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(getDirectoryUsersTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listDirectoryUsersTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.GetDirectoryUsers(context.Background(), test.options)
+			directoryUsers, err := client.ListDirectoryUsers(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -76,7 +76,7 @@ func TestGetDirectoryUsers(t *testing.T) {
 	}
 }
 
-func getDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
+func listDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -89,9 +89,9 @@ func getDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(struct {
-		GetDirectoryUsersResponse
+		ListDirectoryUsersResponse
 	}{
-		GetDirectoryUsersResponse: GetDirectoryUsersResponse{
+		ListDirectoryUsersResponse: ListDirectoryUsersResponse{
 			Data: []DirectoryUser{
 				DirectoryUser{
 					ID:        "directory_usr_id",
@@ -122,12 +122,12 @@ func getDirectoryUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestGetDirectoryGroups(t *testing.T) {
+func TestListDirectoryGroups(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetDirectoryGroupsOpts
-		expected GetDirectoryGroupsResponse
+		options  ListDirectoryGroupsOpts
+		expected ListDirectoryGroupsResponse
 		err      bool
 	}{
 		{
@@ -140,10 +140,10 @@ func TestGetDirectoryGroups(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetDirectoryGroupsOpts{
+			options: ListDirectoryGroupsOpts{
 				DirectoryEndpointID: "directory_edp_test",
 			},
-			expected: GetDirectoryGroupsResponse{
+			expected: ListDirectoryGroupsResponse{
 				Data: []DirectoryGroup{
 					DirectoryGroup{
 						ID:   "directory_grp_id",
@@ -160,14 +160,14 @@ func TestGetDirectoryGroups(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(getDirectoryGroupsTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listDirectoryGroupsTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.GetDirectoryGroups(context.Background(), test.options)
+			directoryUsers, err := client.ListDirectoryGroups(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -178,7 +178,7 @@ func TestGetDirectoryGroups(t *testing.T) {
 	}
 }
 
-func getDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+func listDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -191,9 +191,9 @@ func getDirectoryGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(struct {
-		GetDirectoryGroupsResponse
+		ListDirectoryGroupsResponse
 	}{
-		GetDirectoryGroupsResponse: GetDirectoryGroupsResponse{
+		ListDirectoryGroupsResponse: ListDirectoryGroupsResponse{
 			Data: []DirectoryGroup{
 				DirectoryGroup{
 					ID:   "directory_grp_id",
@@ -307,11 +307,11 @@ func getDirectoryUserTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestGetDirectoryUserGroups(t *testing.T) {
+func TestListDirectoryUserGroups(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetDirectoryUserGroupsOpts
+		options  ListDirectoryUserGroupsOpts
 		expected []DirectoryGroup
 		err      bool
 	}{
@@ -325,7 +325,7 @@ func TestGetDirectoryUserGroups(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetDirectoryUserGroupsOpts{
+			options: ListDirectoryUserGroupsOpts{
 				DirectoryEndpointID: "directory_edp_id",
 				DirectoryUserID:     "directory_usr_id",
 			},
@@ -340,14 +340,14 @@ func TestGetDirectoryUserGroups(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(getDirectoryUserGroupsTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listDirectoryUserGroupsTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.GetDirectoryUserGroups(context.Background(), test.options)
+			directoryUsers, err := client.ListDirectoryUserGroups(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -358,7 +358,7 @@ func TestGetDirectoryUserGroups(t *testing.T) {
 	}
 }
 
-func getDirectoryUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
+func listDirectoryUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -385,12 +385,12 @@ func getDirectoryUserGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestGetDirectories(t *testing.T) {
+func TestListDirectories(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetDirectoriesOpts
-		expected GetDirectoriesResponse
+		options  ListDirectoriesOpts
+		expected ListDirectoriesResponse
 		err      bool
 	}{
 		{
@@ -403,8 +403,8 @@ func TestGetDirectories(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetDirectoriesOpts{},
-			expected: GetDirectoriesResponse{
+			options: ListDirectoriesOpts{},
+			expected: ListDirectoriesResponse{
 				Data: []DirectoryEndpoint{
 					DirectoryEndpoint{
 						ID:          "directory_edp_id",
@@ -426,14 +426,14 @@ func TestGetDirectories(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(getDirectoriesTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(listDirectoriesTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			directoryUsers, err := client.GetDirectories(context.Background(), test.options)
+			directoryUsers, err := client.ListDirectories(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -444,7 +444,7 @@ func TestGetDirectories(t *testing.T) {
 	}
 }
 
-func getDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
+func listDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -456,7 +456,7 @@ func getDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(GetDirectoriesResponse{
+	body, err := json.Marshal(ListDirectoriesResponse{
 		Data: []DirectoryEndpoint{
 			DirectoryEndpoint{
 				ID:          "directory_edp_id",

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -8,9 +8,9 @@
 //	func main() {
 //		directorysync.SetAPIKey("my_api_key")
 //
-//		directoryUsers, err := directorysync.GetDirectoryUsers(
+//		directoryUsers, err := directorysync.ListDirectoryUsers(
 //			context.Background(),
-//			directorysync.GetDirectoryUsersOpts{
+//			directorysync.ListDirectoryUsersOpts{
 //				DirectoryEndpointID: "directory_edp_id",
 //			},
 //		)
@@ -33,20 +33,20 @@ func SetAPIKey(apiKey string) {
 	DefaultClient.APIKey = apiKey
 }
 
-// GetDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
-func GetDirectoryUsers(
+// ListDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
+func ListDirectoryUsers(
 	ctx context.Context,
-	opts GetDirectoryUsersOpts,
-) (GetDirectoryUsersResponse, error) {
-	return DefaultClient.GetDirectoryUsers(ctx, opts)
+	opts ListDirectoryUsersOpts,
+) (ListDirectoryUsersResponse, error) {
+	return DefaultClient.ListDirectoryUsers(ctx, opts)
 }
 
-// GetDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
-func GetDirectoryGroups(
+// ListDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
+func ListDirectoryGroups(
 	ctx context.Context,
-	opts GetDirectoryGroupsOpts,
-) (GetDirectoryGroupsResponse, error) {
-	return DefaultClient.GetDirectoryGroups(ctx, opts)
+	opts ListDirectoryGroupsOpts,
+) (ListDirectoryGroupsResponse, error) {
+	return DefaultClient.ListDirectoryGroups(ctx, opts)
 }
 
 // GetDirectoryUser gets a provisioned User for a Directory Endpoint.
@@ -57,18 +57,18 @@ func GetDirectoryUser(
 	return DefaultClient.GetDirectoryUser(ctx, opts)
 }
 
-// GetDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
-func GetDirectoryUserGroups(
+// ListDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
+func ListDirectoryUserGroups(
 	ctx context.Context,
-	opts GetDirectoryUserGroupsOpts,
+	opts ListDirectoryUserGroupsOpts,
 ) ([]DirectoryGroup, error) {
-	return DefaultClient.GetDirectoryUserGroups(ctx, opts)
+	return DefaultClient.ListDirectoryUserGroups(ctx, opts)
 }
 
-// GetDirectories gets details of a Project's Directory Endpoints.
-func GetDirectories(
+// ListDirectories gets details of a Project's Directory Endpoints.
+func ListDirectories(
 	ctx context.Context,
-	opts GetDirectoriesOpts,
-) (GetDirectoriesResponse, error) {
-	return DefaultClient.GetDirectories(ctx, opts)
+	opts ListDirectoriesOpts,
+) (ListDirectoriesResponse, error) {
+	return DefaultClient.ListDirectories(ctx, opts)
 }

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -1,0 +1,74 @@
+// Package directorysync is a package to fetch Directory information from
+// WorkOS.
+//
+// You first need to setup a Directory Endpoint on
+// https://dashboard.workos.com/directory-sync.
+//
+// Example:
+//	func main() {
+//		directorysync.SetAPIKey("my_api_key")
+//
+//		directoryUsers, err := directorysync.GetDirectoryUsers(
+//			context.Background(),
+//			directorysync.GetDirectoryUsersOpts{
+//				DirectoryEndpointID: "directory_edp_id",
+//			},
+//		)
+//	}
+package directorysync
+
+import (
+	"context"
+)
+
+// DefaultClient is the client used by SetAPIKey and Directory Sync functions.
+var (
+	DefaultClient = &Client{
+		Endpoint: "https://api.workos.com",
+	}
+)
+
+// SetAPIKey sets the WorkOS API key for Directory Sync requests.
+func SetAPIKey(apiKey string) {
+	DefaultClient.APIKey = apiKey
+}
+
+// GetDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
+func GetDirectoryUsers(
+	ctx context.Context,
+	opts GetDirectoryUsersOpts,
+) (GetDirectoryUsersResponse, error) {
+	return DefaultClient.GetDirectoryUsers(ctx, opts)
+}
+
+// GetDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
+func GetDirectoryGroups(
+	ctx context.Context,
+	opts GetDirectoryGroupsOpts,
+) (GetDirectoryGroupsResponse, error) {
+	return DefaultClient.GetDirectoryGroups(ctx, opts)
+}
+
+// GetDirectoryUser gets a provisioned User for a Directory Endpoint.
+func GetDirectoryUser(
+	ctx context.Context,
+	opts GetDirectoryUserOpts,
+) (DirectoryUser, error) {
+	return DefaultClient.GetDirectoryUser(ctx, opts)
+}
+
+// GetDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
+func GetDirectoryUserGroups(
+	ctx context.Context,
+	opts GetDirectoryUserGroupsOpts,
+) ([]DirectoryGroup, error) {
+	return DefaultClient.GetDirectoryUserGroups(ctx, opts)
+}
+
+// GetDirectories gets details of a Project's Directory Endpoints.
+func GetDirectories(
+	ctx context.Context,
+	opts GetDirectoriesOpts,
+) (GetDirectoriesResponse, error) {
+	return DefaultClient.GetDirectories(ctx, opts)
+}

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -33,7 +33,7 @@ func SetAPIKey(apiKey string) {
 	DefaultClient.APIKey = apiKey
 }
 
-// ListUsers gets a list of provisioned Users for a Directory Endpoint.
+// ListUsers gets a list of provisioned Users for a Directory.
 func ListUsers(
 	ctx context.Context,
 	opts ListUsersOpts,
@@ -41,7 +41,7 @@ func ListUsers(
 	return DefaultClient.ListUsers(ctx, opts)
 }
 
-// ListGroups gets a list of provisioned Groups for a Directory Endpoint.
+// ListGroups gets a list of provisioned Groups for a Directory.
 func ListGroups(
 	ctx context.Context,
 	opts ListGroupsOpts,
@@ -49,7 +49,7 @@ func ListGroups(
 	return DefaultClient.ListGroups(ctx, opts)
 }
 
-// GetUser gets a provisioned User for a Directory Endpoint.
+// GetUser gets a provisioned User for a Directory.
 func GetUser(
 	ctx context.Context,
 	opts GetUserOpts,
@@ -57,7 +57,7 @@ func GetUser(
 	return DefaultClient.GetUser(ctx, opts)
 }
 
-// GetGroup gets a provisioned Group for a Directory Endpoint.
+// GetGroup gets a provisioned Group for a Directory.
 func GetGroup(
 	ctx context.Context,
 	opts GetGroupOpts,
@@ -65,7 +65,7 @@ func GetGroup(
 	return DefaultClient.GetGroup(ctx, opts)
 }
 
-// ListDirectories gets details of a Project's Directory Endpoints.
+// ListDirectories gets details of a Project's Directories.
 func ListDirectories(
 	ctx context.Context,
 	opts ListDirectoriesOpts,

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -8,9 +8,9 @@
 //	func main() {
 //		directorysync.SetAPIKey("my_api_key")
 //
-//		directoryUsers, err := directorysync.ListDirectoryUsers(
+//		directoryUsers, err := directorysync.ListUsers(
 //			context.Background(),
-//			directorysync.ListDirectoryUsersOpts{
+//			directorysync.ListUsersOpts{
 //				DirectoryEndpointID: "directory_edp_id",
 //			},
 //		)
@@ -33,36 +33,36 @@ func SetAPIKey(apiKey string) {
 	DefaultClient.APIKey = apiKey
 }
 
-// ListDirectoryUsers gets a list of provisioned Users for a Directory Endpoint.
-func ListDirectoryUsers(
+// ListUsers gets a list of provisioned Users for a Directory Endpoint.
+func ListUsers(
 	ctx context.Context,
-	opts ListDirectoryUsersOpts,
-) (ListDirectoryUsersResponse, error) {
-	return DefaultClient.ListDirectoryUsers(ctx, opts)
+	opts ListUsersOpts,
+) (ListUsersResponse, error) {
+	return DefaultClient.ListUsers(ctx, opts)
 }
 
-// ListDirectoryGroups gets a list of provisioned Groups for a Directory Endpoint.
-func ListDirectoryGroups(
+// ListGroups gets a list of provisioned Groups for a Directory Endpoint.
+func ListGroups(
 	ctx context.Context,
-	opts ListDirectoryGroupsOpts,
-) (ListDirectoryGroupsResponse, error) {
-	return DefaultClient.ListDirectoryGroups(ctx, opts)
+	opts ListGroupsOpts,
+) (ListGroupsResponse, error) {
+	return DefaultClient.ListGroups(ctx, opts)
 }
 
-// GetDirectoryUser gets a provisioned User for a Directory Endpoint.
-func GetDirectoryUser(
+// GetUser gets a provisioned User for a Directory Endpoint.
+func GetUser(
 	ctx context.Context,
-	opts GetDirectoryUserOpts,
+	opts GetUserOpts,
 ) (DirectoryUser, error) {
-	return DefaultClient.GetDirectoryUser(ctx, opts)
+	return DefaultClient.GetUser(ctx, opts)
 }
 
-// ListDirectoryUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
-func ListDirectoryUserGroups(
+// ListUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
+func ListUserGroups(
 	ctx context.Context,
-	opts ListDirectoryUserGroupsOpts,
+	opts ListUserGroupsOpts,
 ) ([]DirectoryGroup, error) {
-	return DefaultClient.ListDirectoryUserGroups(ctx, opts)
+	return DefaultClient.ListUserGroups(ctx, opts)
 }
 
 // ListDirectories gets details of a Project's Directory Endpoints.

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -1,7 +1,7 @@
 // Package directorysync is a package to fetch Directory information from
 // WorkOS.
 //
-// You first need to setup a Directory Endpoint on
+// You first need to setup a Directory on
 // https://dashboard.workos.com/directory-sync.
 //
 // Example:
@@ -11,7 +11,7 @@
 //		directoryUsers, err := directorysync.ListUsers(
 //			context.Background(),
 //			directorysync.ListUsersOpts{
-//				DirectoryEndpointID: "directory_edp_id",
+//				Directory: "directory_id",
 //			},
 //		)
 //	}
@@ -57,12 +57,12 @@ func GetUser(
 	return DefaultClient.GetUser(ctx, opts)
 }
 
-// ListUserGroups gets details of a provisioned User's Groups for a Directory Endpoint.
-func ListUserGroups(
+// GetGroup gets a provisioned Group for a Directory Endpoint.
+func GetGroup(
 	ctx context.Context,
-	opts ListUserGroupsOpts,
-) ([]DirectoryGroup, error) {
-	return DefaultClient.ListUserGroups(ctx, opts)
+	opts GetGroupOpts,
+) (DirectoryGroup, error) {
+	return DefaultClient.GetGroup(ctx, opts)
 }
 
 // ListDirectories gets details of a Project's Directory Endpoints.

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -53,7 +53,7 @@ func ListGroups(
 func GetUser(
 	ctx context.Context,
 	opts GetUserOpts,
-) (DirectoryUser, error) {
+) (User, error) {
 	return DefaultClient.GetUser(ctx, opts)
 }
 
@@ -61,7 +61,7 @@ func GetUser(
 func GetGroup(
 	ctx context.Context,
 	opts GetGroupOpts,
-) (DirectoryGroup, error) {
+) (Group, error) {
 	return DefaultClient.GetGroup(ctx, opts)
 }
 

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -42,7 +42,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 		},
 	}
 	directoryUsersResponse, err := ListUsers(context.Background(), ListUsersOpts{
-		DirectoryEndpointID: "directory_edp_id",
+		Directory: "directory_id",
 	})
 
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestDirectorySyncListGroups(t *testing.T) {
 	directoryGroupsResponse, err := ListGroups(
 		context.Background(),
 		ListGroupsOpts{
-			DirectoryEndpointID: "directory_edp_id",
+			Directory: "directory_id",
 		},
 	)
 
@@ -106,16 +106,15 @@ func TestDirectorySyncGetUser(t *testing.T) {
 		RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 	}
 	directoryUserResponse, err := GetUser(context.Background(), GetUserOpts{
-		DirectoryEndpointID: "directory_edp_id",
-		DirectoryUserID:     "directory_usr_id",
+		User: "directory_usr_id",
 	})
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, directoryUserResponse)
 }
 
-func TestDirectorySyncListUserGroups(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(listUserGroupsTestHandler))
+func TestDirectorySyncGetGroup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getGroupTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -124,22 +123,16 @@ func TestDirectorySyncListUserGroups(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := []DirectoryGroup{
-		DirectoryGroup{
-			ID:   "directory_grp_id",
-			Name: "Scientists",
-		},
+	expectedResponse := DirectoryGroup{
+		ID:   "directory_grp_id",
+		Name: "Scientists",
 	}
-	directoryUserGroupsResponse, err := ListUserGroups(
-		context.Background(),
-		ListUserGroupsOpts{
-			DirectoryEndpointID: "directory_edp_id",
-			DirectoryUserID:     "directory_usr_id",
-		},
-	)
+	directoryGroupResponse, err := GetGroup(context.Background(), GetGroupOpts{
+		Group: "directory_grp_id",
+	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, directoryUserGroupsResponse)
+	require.Equal(t, expectedResponse, directoryGroupResponse)
 }
 
 func TestDirectorySyncListDirectories(t *testing.T) {
@@ -153,9 +146,9 @@ func TestDirectorySyncListDirectories(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := ListDirectoriesResponse{
-		Data: []DirectoryEndpoint{
-			DirectoryEndpoint{
-				ID:          "directory_edp_id",
+		Data: []Directory{
+			Directory{
+				ID:          "directory_id",
 				Name:        "Ri Jeong Hyeok",
 				Domain:      "crashlandingyou.com",
 				ExternalKey: "fried_chicken",

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -157,7 +157,7 @@ func TestDirectorySyncGetDirectories(t *testing.T) {
 			DirectoryEndpoint{
 				ID:          "directory_edp_id",
 				Name:        "Ri Jeong Hyeok",
-				Domain:      "crashlanding@you.com",
+				Domain:      "crashlandingyou.com",
 				ExternalKey: "fried_chicken",
 				State:       "linked",
 				Type:        "gsuite directory",

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDirectorySyncListUsers(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(listDirectoryUsersTestHandler))
+	server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -20,7 +20,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := ListDirectoryUsersResponse{
+	expectedResponse := ListUsersResponse{
 		Data: []DirectoryUser{
 			DirectoryUser{
 				ID:        "directory_usr_id",
@@ -41,7 +41,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 			After:  "",
 		},
 	}
-	directoryUsersResponse, err := ListDirectoryUsers(context.Background(), ListDirectoryUsersOpts{
+	directoryUsersResponse, err := ListUsers(context.Background(), ListUsersOpts{
 		DirectoryEndpointID: "directory_edp_id",
 	})
 
@@ -50,7 +50,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 }
 
 func TestDirectorySyncListGroups(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(listDirectoryGroupsTestHandler))
+	server := httptest.NewServer(http.HandlerFunc(listGroupsTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -59,7 +59,7 @@ func TestDirectorySyncListGroups(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := ListDirectoryGroupsResponse{
+	expectedResponse := ListGroupsResponse{
 		Data: []DirectoryGroup{
 			DirectoryGroup{
 				ID:   "directory_grp_id",
@@ -71,9 +71,9 @@ func TestDirectorySyncListGroups(t *testing.T) {
 			After:  "",
 		},
 	}
-	directoryGroupsResponse, err := ListDirectoryGroups(
+	directoryGroupsResponse, err := ListGroups(
 		context.Background(),
-		ListDirectoryGroupsOpts{
+		ListGroupsOpts{
 			DirectoryEndpointID: "directory_edp_id",
 		},
 	)
@@ -83,7 +83,7 @@ func TestDirectorySyncListGroups(t *testing.T) {
 }
 
 func TestDirectorySyncGetUser(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(getDirectoryUserTestHandler))
+	server := httptest.NewServer(http.HandlerFunc(getUserTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -105,7 +105,7 @@ func TestDirectorySyncGetUser(t *testing.T) {
 		},
 		RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 	}
-	directoryUserResponse, err := GetDirectoryUser(context.Background(), GetDirectoryUserOpts{
+	directoryUserResponse, err := GetUser(context.Background(), GetUserOpts{
 		DirectoryEndpointID: "directory_edp_id",
 		DirectoryUserID:     "directory_usr_id",
 	})
@@ -115,7 +115,7 @@ func TestDirectorySyncGetUser(t *testing.T) {
 }
 
 func TestDirectorySyncListUserGroups(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(listDirectoryUserGroupsTestHandler))
+	server := httptest.NewServer(http.HandlerFunc(listUserGroupsTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -130,9 +130,9 @@ func TestDirectorySyncListUserGroups(t *testing.T) {
 			Name: "Scientists",
 		},
 	}
-	directoryUserGroupsResponse, err := ListDirectoryUserGroups(
+	directoryUserGroupsResponse, err := ListUserGroups(
 		context.Background(),
-		ListDirectoryUserGroupsOpts{
+		ListUserGroupsOpts{
 			DirectoryEndpointID: "directory_edp_id",
 			DirectoryUserID:     "directory_usr_id",
 		},

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -1,0 +1,179 @@
+package directorysync
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectorySyncGetUsers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getDirectoryUsersTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := GetDirectoryUsersResponse{
+		Data: []DirectoryUser{
+			DirectoryUser{
+				ID:        "directory_usr_id",
+				FirstName: "Rick",
+				LastName:  "Sanchez",
+				Emails: []DirectoryUserEmail{
+					DirectoryUserEmail{
+						Primary: true,
+						Type:    "work",
+						Value:   "rick@sanchez.com",
+					},
+				},
+				RawAttributes: json.RawMessage(`{"foo":"bar"}`),
+			},
+		},
+		ListMetadata: ListMetadata{
+			Before: "",
+			After:  "",
+		},
+	}
+	directoryUsersResponse, err := GetDirectoryUsers(context.Background(), GetDirectoryUsersOpts{
+		DirectoryEndpointID: "directory_edp_id",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, directoryUsersResponse)
+}
+
+func TestDirectorySyncGetGroups(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getDirectoryGroupsTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := GetDirectoryGroupsResponse{
+		Data: []DirectoryGroup{
+			DirectoryGroup{
+				ID:   "directory_grp_id",
+				Name: "Scientists",
+			},
+		},
+		ListMetadata: ListMetadata{
+			Before: "",
+			After:  "",
+		},
+	}
+	directoryGroupsResponse, err := GetDirectoryGroups(
+		context.Background(),
+		GetDirectoryGroupsOpts{
+			DirectoryEndpointID: "directory_edp_id",
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, directoryGroupsResponse)
+}
+
+func TestDirectorySyncGetUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getDirectoryUserTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := DirectoryUser{
+		ID:        "directory_usr_id",
+		FirstName: "Rick",
+		LastName:  "Sanchez",
+		Emails: []DirectoryUserEmail{
+			DirectoryUserEmail{
+				Primary: true,
+				Type:    "work",
+				Value:   "rick@sanchez.com",
+			},
+		},
+		RawAttributes: json.RawMessage(`{"foo":"bar"}`),
+	}
+	directoryUserResponse, err := GetDirectoryUser(context.Background(), GetDirectoryUserOpts{
+		DirectoryEndpointID: "directory_edp_id",
+		DirectoryUserID:     "directory_usr_id",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, directoryUserResponse)
+}
+
+func TestDirectorySyncGetUserGroups(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getDirectoryUserGroupsTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := []DirectoryGroup{
+		DirectoryGroup{
+			ID:   "directory_grp_id",
+			Name: "Scientists",
+		},
+	}
+	directoryUserGroupsResponse, err := GetDirectoryUserGroups(
+		context.Background(),
+		GetDirectoryUserGroupsOpts{
+			DirectoryEndpointID: "directory_edp_id",
+			DirectoryUserID:     "directory_usr_id",
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, directoryUserGroupsResponse)
+}
+
+func TestDirectorySyncGetDirectories(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getDirectoriesTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := GetDirectoriesResponse{
+		Data: []DirectoryEndpoint{
+			DirectoryEndpoint{
+				ID:          "directory_edp_id",
+				Name:        "Ri Jeong Hyeok",
+				Domain:      "crashlanding@you.com",
+				ExternalKey: "fried_chicken",
+				State:       "linked",
+				Type:        "gsuite directory",
+				ProjectID:   "project_id",
+			},
+		},
+		ListMetadata: ListMetadata{
+			Before: "",
+			After:  "",
+		},
+	}
+	directoriesResponse, err := GetDirectories(
+		context.Background(),
+		GetDirectoriesOpts{},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, directoriesResponse)
+}

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDirectorySyncGetUsers(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(getDirectoryUsersTestHandler))
+func TestDirectorySyncListUsers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listDirectoryUsersTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -20,7 +20,7 @@ func TestDirectorySyncGetUsers(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := GetDirectoryUsersResponse{
+	expectedResponse := ListDirectoryUsersResponse{
 		Data: []DirectoryUser{
 			DirectoryUser{
 				ID:        "directory_usr_id",
@@ -41,7 +41,7 @@ func TestDirectorySyncGetUsers(t *testing.T) {
 			After:  "",
 		},
 	}
-	directoryUsersResponse, err := GetDirectoryUsers(context.Background(), GetDirectoryUsersOpts{
+	directoryUsersResponse, err := ListDirectoryUsers(context.Background(), ListDirectoryUsersOpts{
 		DirectoryEndpointID: "directory_edp_id",
 	})
 
@@ -49,8 +49,8 @@ func TestDirectorySyncGetUsers(t *testing.T) {
 	require.Equal(t, expectedResponse, directoryUsersResponse)
 }
 
-func TestDirectorySyncGetGroups(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(getDirectoryGroupsTestHandler))
+func TestDirectorySyncListGroups(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listDirectoryGroupsTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -59,7 +59,7 @@ func TestDirectorySyncGetGroups(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := GetDirectoryGroupsResponse{
+	expectedResponse := ListDirectoryGroupsResponse{
 		Data: []DirectoryGroup{
 			DirectoryGroup{
 				ID:   "directory_grp_id",
@@ -71,9 +71,9 @@ func TestDirectorySyncGetGroups(t *testing.T) {
 			After:  "",
 		},
 	}
-	directoryGroupsResponse, err := GetDirectoryGroups(
+	directoryGroupsResponse, err := ListDirectoryGroups(
 		context.Background(),
-		GetDirectoryGroupsOpts{
+		ListDirectoryGroupsOpts{
 			DirectoryEndpointID: "directory_edp_id",
 		},
 	)
@@ -114,8 +114,8 @@ func TestDirectorySyncGetUser(t *testing.T) {
 	require.Equal(t, expectedResponse, directoryUserResponse)
 }
 
-func TestDirectorySyncGetUserGroups(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(getDirectoryUserGroupsTestHandler))
+func TestDirectorySyncListUserGroups(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listDirectoryUserGroupsTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -130,9 +130,9 @@ func TestDirectorySyncGetUserGroups(t *testing.T) {
 			Name: "Scientists",
 		},
 	}
-	directoryUserGroupsResponse, err := GetDirectoryUserGroups(
+	directoryUserGroupsResponse, err := ListDirectoryUserGroups(
 		context.Background(),
-		GetDirectoryUserGroupsOpts{
+		ListDirectoryUserGroupsOpts{
 			DirectoryEndpointID: "directory_edp_id",
 			DirectoryUserID:     "directory_usr_id",
 		},
@@ -142,8 +142,8 @@ func TestDirectorySyncGetUserGroups(t *testing.T) {
 	require.Equal(t, expectedResponse, directoryUserGroupsResponse)
 }
 
-func TestDirectorySyncGetDirectories(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(getDirectoriesTestHandler))
+func TestDirectorySyncListDirectories(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listDirectoriesTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -152,7 +152,7 @@ func TestDirectorySyncGetDirectories(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := GetDirectoriesResponse{
+	expectedResponse := ListDirectoriesResponse{
 		Data: []DirectoryEndpoint{
 			DirectoryEndpoint{
 				ID:          "directory_edp_id",
@@ -169,9 +169,9 @@ func TestDirectorySyncGetDirectories(t *testing.T) {
 			After:  "",
 		},
 	}
-	directoriesResponse, err := GetDirectories(
+	directoriesResponse, err := ListDirectories(
 		context.Background(),
-		GetDirectoriesOpts{},
+		ListDirectoriesOpts{},
 	)
 
 	require.NoError(t, err)

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -21,13 +21,13 @@ func TestDirectorySyncListUsers(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := ListUsersResponse{
-		Data: []DirectoryUser{
-			DirectoryUser{
+		Data: []User{
+			User{
 				ID:        "directory_usr_id",
 				FirstName: "Rick",
 				LastName:  "Sanchez",
-				Emails: []DirectoryUserEmail{
-					DirectoryUserEmail{
+				Emails: []UserEmail{
+					UserEmail{
 						Primary: true,
 						Type:    "work",
 						Value:   "rick@sanchez.com",
@@ -60,8 +60,8 @@ func TestDirectorySyncListGroups(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := ListGroupsResponse{
-		Data: []DirectoryGroup{
-			DirectoryGroup{
+		Data: []Group{
+			Group{
 				ID:   "directory_grp_id",
 				Name: "Scientists",
 			},
@@ -92,12 +92,12 @@ func TestDirectorySyncGetUser(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := DirectoryUser{
+	expectedResponse := User{
 		ID:        "directory_usr_id",
 		FirstName: "Rick",
 		LastName:  "Sanchez",
-		Emails: []DirectoryUserEmail{
-			DirectoryUserEmail{
+		Emails: []UserEmail{
+			UserEmail{
 				Primary: true,
 				Type:    "work",
 				Value:   "rick@sanchez.com",
@@ -123,7 +123,7 @@ func TestDirectorySyncGetGroup(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := DirectoryGroup{
+	expectedResponse := Group{
 		ID:   "directory_grp_id",
 		Name: "Scientists",
 	}


### PR DESCRIPTION
Offers functions to retrieve Directory data via the WorkOS API.

Retrieve Directory Users
```go
directorysync.ListUsers(context.Background(), ListUsersOpts{
	Directory: "directory_id",
})
```

Retrieve Directory Groups
```go
directorysync.ListGroups(
	context.Background(),
	ListGroupsOpts{
		Directory: "directory_id",
	},
)
```

Retrieve a single Directory User
```go
directorysync.GetUser(context.Background(), GetUserOpts{
	User:     "directory_usr_id",
})
```

Retrieve a single Directory Group
```go
directorysync.GetGroup(
	context.Background(),
	GetGroupOpts{
		Group:     "directory_grp_id",
	},
)
```

Retrieve a Project's Directories
```go
directorysync.ListDirectories(
	context.Background(),
	ListDirectoriesOpts{},
)
```