### PR TITLE
Add support to fetch Audit Trail events

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,8 +28,9 @@ blocks:
         - name: go test
           commands:
             - checkout
-            - sem-version go 1.12
-            - go get github.com/stretchr/testify/...
+            - sem-version go 1.14
+            - go get github.com/stretchr/testify
+            - go get github.com/google/go-querystring
             - go get github.com/google/uuid
             - go get github.com/tidwall/gjson
             - go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/workos-inc/workos-go
 go 1.13
 
 require (
+	github.com/google/go-querystring v1.0.0
 	github.com/google/uuid v1.1.1
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.6.1
 	github.com/tidwall/gjson v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -8,6 +10,8 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/gjson v1.4.0 h1:w6iOJZt9BJOzz4VD9CSnRCX/oleCsAZWi+1FFzZA+SA=
 github.com/tidwall/gjson v1.4.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
@@ -18,3 +22,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/audittrail/README.md
+++ b/pkg/audittrail/README.md
@@ -21,7 +21,7 @@ func main() {
     audittrail.SetAPIKey("my_api_key")
 
     // Wherever you need to publish an audit trail event:
-    err := audittrail.Publish(ctx.Background(), audittrail.Event{
+    err := audittrail.Publish(ctx.Background(), audittrail.EventOpts{
         Action:     "document.viewed",
         ActionType: audittrail.Create,
         ActorName:  "Jairo Kunde",

--- a/pkg/audittrail/audittrail.go
+++ b/pkg/audittrail/audittrail.go
@@ -5,7 +5,7 @@
 //       audittrail.SetAPIKey("my_api_key")
 //
 //       // Wherever you need to publish an audit trail event:
-//       err := audittrail.Publish(context.Background(), audittrail.Event{
+//       err := audittrail.Publish(context.Background(), audittrail.EventOpts{
 //           Action:     "document.viewed",
 //           ActionType: audittrail.Create,
 //           ActorName:  "Jairo Kunde",
@@ -25,8 +25,6 @@ package audittrail
 import (
 	"context"
 	"errors"
-	"fmt"
-	"time"
 )
 
 var (
@@ -47,84 +45,11 @@ func SetAPIKey(k string) {
 }
 
 // Publish publishes the given event.
-func Publish(ctx context.Context, e Event) error {
+func Publish(ctx context.Context, e EventOpts) error {
 	return DefaultClient.Publish(ctx, e)
 }
 
-// Event represents an Audit Trail event.
-type Event struct {
-	Action     string     `json:"action"`
-	ActionType ActionType `json:"action_type"`
-	ActorName  string     `json:"actor_name"`
-	ActorID    string     `json:"actor_id"`
-	Group      string     `json:"group"`
-
-	// A key that ensures that the same event is not processed multiple times.
-	// Once the event is sent for the first time, the lock on the key expires
-	// after 24 hours.
-
-	// If no key is provided or the key is empty, the key will not be attached
-	// to the request.
-	IdempotencyKey string `json:"-"`
-
-	// An ip address that locates where the audit trail occurred.
-	Location string `json:"location"`
-
-	// The event metadata. It can't contain more than 50 keys. A key can't
-	// exeed 40 characters.
-	Metadata Metadata `json:"metadata,omitempty"`
-
-	// The time when the audit trail occurred.
-	//
-	// Defaults to time.Now().
-	OccurredAt time.Time `json:"occurred_at"`
-
-	TargetName string `json:"target_name"`
-	TargetID   string `json:"target_id"`
-}
-
-// ActionType is the type that holds the CRUD action used for the WorkOS Audit
-// Log.
-type ActionType string
-
-// Constants that enumerate the different action types.
-const (
-	Create ActionType = "C"
-	Read   ActionType = "R"
-	Update ActionType = "U"
-	Delete ActionType = "D"
-)
-
-// Metadata represents metadata to be attached to an audit trail event.
-type Metadata map[string]interface{}
-
-// Merges the given metadata. Values from m are not overridden by the ones from
-// other.
-func (m Metadata) merge(other Metadata) {
-	for k, v := range other {
-		if _, ok := m[k]; !ok {
-			m[k] = v
-		}
-	}
-}
-
-func (m Metadata) validate() error {
-	if len(m) > 50 {
-		return errTooMuchMetadataKeys
-	}
-
-	for k := range m {
-		if l := len(k); l > 40 {
-			return fmt.Errorf("metadata key %q exceed 40 characters: %d", k, l)
-		}
-	}
-
-	return nil
-}
-
-func defaultTime(t time.Time) time.Time {
-	if t == (time.Time{}) {
-		t = time.Now().UTC()
-	}
-	return t
+// ListEvents fetches Audit Trail events.
+func ListEvents(ctx context.Context, opts ListEventsOpts) (ListEventsResponse, error) {
+	return DefaultClient.ListEvents(ctx, opts)
 }

--- a/pkg/audittrail/client.go
+++ b/pkg/audittrail/client.go
@@ -4,12 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/google/go-querystring/query"
+
 	"github.com/workos-inc/workos-go/internal/workos"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
+
+// ResponseLimit is the default number of records to limit a response to.
+const ResponseLimit = 10
 
 // Client represents a client that performs audittrail requests to WorkOS API.
 type Client struct {
@@ -31,6 +38,53 @@ type Client struct {
 	once sync.Once
 }
 
+// EventOpts represents arguments to create an Audit Trail event.
+type EventOpts struct {
+	// Specific activity performed by the actor.
+	Action string `json:"action"`
+
+	// Corresponding CRUD category of the Event.
+	ActionType string `json:"action_type"`
+
+	// Display name of the entity performing the action.
+	ActorName string `json:"actor_name"`
+
+	// Unique identifier of the entity performing the action.
+	ActorID string `json:"actor_id"`
+
+	// A single domain containing related members.
+	Group string `json:"group"`
+
+	// A key that ensures that the same event is not processed multiple times.
+	// Once the event is sent for the first time, the lock on the key expires
+	// after 24 hours.
+
+	// If no key is provided or the key is empty, the key will not be attached
+	// to the request.
+	IdempotencyKey string `json:"-"`
+
+	// An ip address that locates where the audit trail occurred.
+	Location string `json:"location"`
+
+	// The event metadata. It can't contain more than 50 keys. A key can't
+	// exeed 40 characters.
+	Metadata Metadata `json:"metadata,omitempty"`
+
+	// The time when the audit trail occurred.
+	//
+	// Defaults to time.Now().
+	OccurredAt time.Time `json:"occurred_at"`
+
+	// Display name of the object or resource that is being acted upon.
+	TargetName string `json:"target_name"`
+
+	// Unique identifier of the object or resource being acted upon.
+	TargetID string `json:"target_id"`
+}
+
+// Metadata represents metadata to be attached to an audit trail event.
+type Metadata map[string]interface{}
+
 func (c *Client) init() {
 	if c.HTTPClient == nil {
 		c.HTTPClient = &http.Client{Timeout: 10 * time.Second}
@@ -46,7 +100,7 @@ func (c *Client) init() {
 }
 
 // Publish publishes the given event.
-func (c *Client) Publish(ctx context.Context, e Event) error {
+func (c *Client) Publish(ctx context.Context, e EventOpts) error {
 	c.once.Do(c.init)
 
 	if err := e.Metadata.validate(); err != nil {
@@ -80,4 +134,194 @@ func (c *Client) Publish(ctx context.Context, e Event) error {
 	defer res.Body.Close()
 
 	return workos.TryGetHTTPError(res)
+}
+
+// ListEventsOpts contains options to fetch Audit Trail events.
+type ListEventsOpts struct {
+	// List of Groups to filter for.
+	Group []string `url:"group,brackets,omitempty"`
+
+	// List of Actions to filter for.
+	Action []string `url:"action,brackets,omitempty"`
+
+	// List of Action Types to filter for.
+	ActionType []string `url:"action_type,brackets,omitempty"`
+
+	// List of Actor Names to filter for.
+	ActorName []string `url:"actor_name,brackets,omitempty"`
+
+	// List of Actor IDs to filter for.
+	ActorID []string `url:"actor_id,brackets,omitempty"`
+
+	// List of Target Names to filter for.
+	TargetName []string `url:"target_name,brackets,omitempty"`
+
+	// List of Target IDs to filter for.
+	TargetID []string `url:"target_id,brackets,omitempty"`
+
+	// ISO-8601 datetime of when an event occurred.
+	OccurredAt string `url:"occurred_at,omitempty"`
+
+	// ISO-8601 datetime of when an event occurred after.
+	OccurredAtGt string `url:"occurred_at_gt,omitempty"`
+
+	// ISO-8601 datetime of when an event occurred at or after.
+	OccurredAtGte string `url:"occurred_at_gte,omitempty"`
+
+	// ISO-8601 datetime of when an event occurred before.
+	OccurredAtLt string `url:"occurred_at_lt,omitempty"`
+
+	// ISO-8601 datetime of when an event occured at or before.
+	OccurredAtLte string `url:"occurred_at_lte,omitempty"`
+
+	// Keyword search.
+	Search string `url:"search,omitempty"`
+
+	// Maximum number of records to return.
+	Limit int `url:"limit"`
+
+	// Pagination cursor to receive records before a provided Event ID.
+	Before string `url:"before,omitempty"`
+
+	// Pagination cursor to receive records after a provided Event ID.
+	After string `url:"after,omitempty"`
+}
+
+// EventAction describes an Audit Trail Event Action record.
+type EventAction struct {
+	// Event Action identifier.
+	ID string `json:"id"`
+
+	// Event Action name.
+	Name string `json:"name"`
+
+	// Identifier for the project the Event Action belongs to.
+	ProjectID string `json:"project_id"`
+}
+
+// Event describes an Audit Trail Event record.
+type Event struct {
+	// Event identifier.
+	ID string `json:"id"`
+
+	// A single domain containing related members.
+	Group string `json:"group"`
+
+	// Identifier for where the Event originated.
+	Location string `json:"location"`
+
+	// Latitude for where the Event originated.
+	Latitude string `json:"latitude"`
+
+	// Longitude for where the Event originated.
+	Longitude string `json:"longitude"`
+
+	// Corresponding CRUD category of the Event.
+	Type string `json:"event_type"`
+
+	// Display name of the entity performing the action.
+	ActorName string `json:"actor_name"`
+
+	// Unique identifier of the entity performing the action.
+	ActorID string `json:"actor_id"`
+
+	// Display name of the object or resource that is being acted upon.
+	TargetName string `json:"target_name"`
+
+	// Unique identifier of the object or resource being acted upon.
+	TargetID string `json:"target_id"`
+
+	// ISO-8601 datetime at which the Event happened.
+	OccurredAt string `json:"occurred_at"`
+
+	// Specific activity performed by the actor.
+	Action EventAction `json:"action"`
+
+	// Arbitrary key-value data containing information associated with the Event
+	Metadata Metadata `json:"metadata"`
+}
+
+// ListEventsResponse describes the response structure when requesting
+// Audit Trail events.
+type ListEventsResponse struct {
+	// List of Events.
+	Data []Event `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata common.ListMetadata `json:"listMetadata"`
+}
+
+// ListEvents gets a list of Audit Trail events.
+func (c *Client) ListEvents(ctx context.Context, opts ListEventsOpts) (ListEventsResponse, error) {
+	c.once.Do(c.init)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		c.Endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListEventsResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	if opts.Limit == 0 {
+		opts.Limit = ResponseLimit
+	}
+
+	v, err := query.Values(opts)
+	if err != nil {
+		return ListEventsResponse{}, err
+	}
+
+	req.URL.RawQuery = v.Encode()
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListEventsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return ListEventsResponse{}, err
+	}
+
+	var body ListEventsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// Merges the given metadata. Values from m are not overridden by the ones from
+// other.
+func (m Metadata) merge(other Metadata) {
+	for k, v := range other {
+		if _, ok := m[k]; !ok {
+			m[k] = v
+		}
+	}
+}
+
+func (m Metadata) validate() error {
+	if len(m) > 50 {
+		return errTooMuchMetadataKeys
+	}
+
+	for k := range m {
+		if l := len(k); l > 40 {
+			return fmt.Errorf("metadata key %q exceed 40 characters: %d", k, l)
+		}
+	}
+
+	return nil
+}
+
+func defaultTime(t time.Time) time.Time {
+	if t == (time.Time{}) {
+		t = time.Now().UTC()
+	}
+	return t
 }

--- a/pkg/common/list_metadata.go
+++ b/pkg/common/list_metadata.go
@@ -1,0 +1,10 @@
+package common
+
+// ListMetadata contains pagination options for WorkOS records.
+type ListMetadata struct {
+	// Pagination cursor to receive records before a provided ID.
+	Before string `json:"before"`
+
+	// Pagination cursor to receive records after a provided ID.
+	After string `json:"after"`
+}

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/workos-inc/workos-go/internal/workos"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.
@@ -73,15 +74,6 @@ type User struct {
 	RawAttributes json.RawMessage `json:"raw_attributes"`
 }
 
-// ListMetadata contains pagination options for Directory records.
-type ListMetadata struct {
-	// Pagination cursor to receive records before a provided ID.
-	Before string `json:"before"`
-
-	// Pagination cursor to receive records after a provided ID.
-	After string `json:"after"`
-}
-
 // ListUsersOpts contains the options to request provisioned Directory Users.
 type ListUsersOpts struct {
 	// Directory unique identifier.
@@ -107,7 +99,7 @@ type ListUsersResponse struct {
 	Data []User `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
 // ListUsers gets a list of provisioned Users for a Directory.
@@ -198,7 +190,7 @@ type ListGroupsResponse struct {
 	Data []Group `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
 // ListGroups gets a list of provisioned Groups for a Directory Endpoint.
@@ -425,7 +417,7 @@ type ListDirectoriesResponse struct {
 	Data []Directory `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
 // ListDirectories gets details of existing Directories.

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestListUsers(t *testing.T) {
@@ -48,7 +49,7 @@ func TestListUsers(t *testing.T) {
 						RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 					},
 				},
-				ListMetadata: ListMetadata{
+				ListMetadata: common.ListMetadata{
 					Before: "",
 					After:  "",
 				},
@@ -107,7 +108,7 @@ func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 					RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 				},
 			},
-			ListMetadata: ListMetadata{
+			ListMetadata: common.ListMetadata{
 				Before: "",
 				After:  "",
 			},
@@ -150,7 +151,7 @@ func TestListGroups(t *testing.T) {
 						Name: "Scientists",
 					},
 				},
-				ListMetadata: ListMetadata{
+				ListMetadata: common.ListMetadata{
 					Before: "",
 					After:  "",
 				},
@@ -200,7 +201,7 @@ func listGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 					Name: "Scientists",
 				},
 			},
-			ListMetadata: ListMetadata{
+			ListMetadata: common.ListMetadata{
 				Before: "",
 				After:  "",
 			},
@@ -410,7 +411,7 @@ func TestListDirectories(t *testing.T) {
 						ProjectID:   "project_id",
 					},
 				},
-				ListMetadata: ListMetadata{
+				ListMetadata: common.ListMetadata{
 					Before: "",
 					After:  "",
 				},
@@ -462,7 +463,7 @@ func listDirectoriesTestHandler(w http.ResponseWriter, r *http.Request) {
 				ProjectID:   "project_id",
 			},
 		},
-		ListMetadata: ListMetadata{
+		ListMetadata: common.ListMetadata{
 			Before: "",
 			After:  "",
 		},

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestDirectorySyncListUsers(t *testing.T) {
@@ -36,7 +37,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 				RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 			},
 		},
-		ListMetadata: ListMetadata{
+		ListMetadata: common.ListMetadata{
 			Before: "",
 			After:  "",
 		},
@@ -66,7 +67,7 @@ func TestDirectorySyncListGroups(t *testing.T) {
 				Name: "Scientists",
 			},
 		},
-		ListMetadata: ListMetadata{
+		ListMetadata: common.ListMetadata{
 			Before: "",
 			After:  "",
 		},
@@ -157,7 +158,7 @@ func TestDirectorySyncListDirectories(t *testing.T) {
 				ProjectID:   "project_id",
 			},
 		},
-		ListMetadata: ListMetadata{
+		ListMetadata: common.ListMetadata{
 			Before: "",
 			After:  "",
 		},


### PR DESCRIPTION
* Add `ListEvents` to fetch Audit Trail events from the WorkOS API
* Bump Semaphore Go version to 1.14
* Remove `ActionType` type
* Add [github.com/google/go-querystring](https://github.com/google/go-querystring)