### PR TITLE
Expose raw_attributes on Profile

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v0.4.0"
+	Version = "v0.5.0"
 )

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -165,6 +165,9 @@ type Profile struct {
 
 	// The user last name. Can be empty.
 	LastName string `json:"last_name"`
+
+	// The raw response of Profile attributes from the identity provider
+	RawAttributes map[string]interface{} `json:"raw_attributes"`
 }
 
 // GetProfile returns a profile describing the user that authenticated with

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -114,6 +114,12 @@ func TestClientGetProfile(t *testing.T) {
 				Email:          "foo@test.com",
 				FirstName:      "foo",
 				LastName:       "bar",
+				RawAttributes: map[string]interface{}{
+					"idp_id":     "123",
+					"email":      "foo@test.com",
+					"first_name": "foo",
+					"last_name":  "bar",
+				},
 			},
 		},
 	}
@@ -167,6 +173,12 @@ func profileTestHandler(w http.ResponseWriter, r *http.Request) {
 			Email:          "foo@test.com",
 			FirstName:      "foo",
 			LastName:       "bar",
+			RawAttributes: map[string]interface{}{
+				"idp_id":     "123",
+				"email":      "foo@test.com",
+				"first_name": "foo",
+				"last_name":  "bar",
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -25,6 +25,12 @@ func TestLogin(t *testing.T) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		RawAttributes: map[string]interface{}{
+			"idp_id":     "123",
+			"email":      "foo@test.com",
+			"first_name": "foo",
+			"last_name":  "bar",
+		},
 	}
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
* On the API, we recently exposed raw_attributes, the original profile
response we receive from the IdP. This update passes this data through
the SDK.
* Updates the SDK to 0.5.0