### PR TITLE
Feature/ch3304/add list organizations method to the go sdk

### DIFF
--- a/pkg/portal/README.md
+++ b/pkg/portal/README.md
@@ -1,0 +1,35 @@
+# portal
+
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos-inc/workos-go/pkg/portal)
+
+A Go package to make requests to the WorkOS Admin Portal API.
+
+## Install
+
+```sh
+go get -u github.com/workos-inc/workos-go/pkg/portal
+```
+
+## How it works
+
+You first need to configure your Admin Portal settings on [workos.com](https://dashboard.workos.com/admin-portal).
+
+```go
+package main
+
+import "github.com/workos-inc/workos-go/pkg/portal"
+
+func main() {
+  portal.SetAPIKey("my_api_key")
+
+  organizations, err := portal.ListOrganizations(
+    context.Background(),
+    portal.ListOrganizationsOpts{
+      Domains: []string{"foo-corp.com"},
+    },
+  )
+  if err != nil {
+      // Handle error.
+  }
+}
+```

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/workos-inc/workos-go/internal/workos"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.
@@ -61,15 +62,6 @@ type Organization struct {
 	Domains []OrganizationDomain `json:"domains"`
 }
 
-// ListMetadata contains pagination options for organization records.
-type ListMetadata struct {
-	// Pagination cursor to receive records before a provided ID.
-	Before string `json:"before"`
-
-	// Pagination cursor to receive records after a provided ID.
-	After string `json:"after"`
-}
-
 // ListOrganizationsOpts contains the options to request Organizations.
 type ListOrganizationsOpts struct {
 	// Domains of the Organization.
@@ -92,7 +84,7 @@ type ListOrganizationsResponse struct {
 	Data []Organization `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
 // ListOrganizations gets a list of WorkOS Organizations.

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -1,0 +1,150 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/workos-inc/workos-go/internal/workos"
+)
+
+// ResponseLimit is the default number of records to limit a response to.
+const ResponseLimit = 10
+
+// Client represents a client that performs Admin Portal requests to the WorkOS API.
+type Client struct {
+	// The WorkOS API Key. It can be found in https://dashboard.workos.com/api-keys.
+	APIKey string
+
+	// The http.Client that is used to manage Admin Portal records from WorkOS.
+	// Defaults to http.Client.
+	HTTPClient *http.Client
+
+	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
+	Endpoint string
+
+	once sync.Once
+}
+
+func (c *Client) init() {
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	if c.Endpoint == "" {
+		c.Endpoint = "https://api.workos.com"
+	}
+}
+
+// OrganizationDomain contains data about an Organization's Domains.
+type OrganizationDomain struct {
+	// The Organization Domains's unique identifier.
+	ID string `json:"id"`
+
+	// The domain value
+	Domain string `json:"domain"`
+}
+
+// Organization contains data about a WorkOS Organization.
+type Organization struct {
+	// The Organization's unique identifier.
+	ID string `json:"id"`
+
+	// The Organization's name.
+	Name string `json:"name"`
+
+	// The Organization's Domains.
+	Domains []OrganizationDomain `json:"domains"`
+}
+
+// ListMetadata contains pagination options for organization records.
+type ListMetadata struct {
+	// Pagination cursor to receive records before a provided ID.
+	Before string `json:"before"`
+
+	// Pagination cursor to receive records after a provided ID.
+	After string `json:"after"`
+}
+
+// ListOrganizationsOpts contains the options to request Organizations.
+type ListOrganizationsOpts struct {
+	// Domains of the Organization.
+	Domains []string
+
+	// Maximum number of records to return.
+	Limit int
+
+	// Pagination cursor to receive records before a provided Organization ID.
+	Before string
+
+	// Pagination cursor to receive records after a provided Organization ID.
+	After string
+}
+
+// ListOrganizationsResponse describes the response structure when requesting
+// Organizations
+type ListOrganizationsResponse struct {
+	// List of provisioned Organizations.
+	Data []Organization `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata ListMetadata `json:"listMetadata"`
+}
+
+// ListOrganizations gets a list of WorkOS Organizations.
+func (c *Client) ListOrganizations(
+	ctx context.Context,
+	opts ListOrganizationsOpts,
+) (ListOrganizationsResponse, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf("%s/organizations", c.Endpoint)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListOrganizationsResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	limit := ResponseLimit
+	if opts.Limit != 0 {
+		limit = opts.Limit
+	}
+	q := req.URL.Query()
+
+	if len(opts.Domains) > 0 {
+		for _, domain := range opts.Domains {
+			q.Add("domains", domain)
+		}
+	}
+	q.Add("before", opts.Before)
+	q.Add("after", opts.After)
+	q.Add("limit", strconv.Itoa(limit))
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListOrganizationsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return ListOrganizationsResponse{}, err
+	}
+
+	var body ListOrganizationsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -1,0 +1,118 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListOrganizations(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  ListOrganizationsOpts
+		expected ListOrganizationsResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Organizations",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: ListOrganizationsOpts{
+				Domains: []string{"foo-corp.com"},
+			},
+
+			expected: ListOrganizationsResponse{
+				Data: []Organization{
+					Organization{
+						ID:   "organization_id",
+						Name: "Foo Corp",
+						Domains: []OrganizationDomain{
+							OrganizationDomain{
+								ID:     "organization_domain_id",
+								Domain: "foo-corp.com",
+							},
+						},
+					},
+				},
+				ListMetadata: ListMetadata{
+					Before: "",
+					After:  "",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(listOrganizationsTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			organizations, err := client.ListOrganizations(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, organizations)
+		})
+	}
+}
+
+func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(struct {
+		ListOrganizationsResponse
+	}{
+		ListOrganizationsResponse: ListOrganizationsResponse{
+			Data: []Organization{
+				Organization{
+					ID:   "organization_id",
+					Name: "Foo Corp",
+					Domains: []OrganizationDomain{
+						OrganizationDomain{
+							ID:     "organization_domain_id",
+							Domain: "foo-corp.com",
+						},
+					},
+				},
+			},
+			ListMetadata: ListMetadata{
+				Before: "",
+				After:  "",
+			},
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestListOrganizations(t *testing.T) {
@@ -46,7 +47,7 @@ func TestListOrganizations(t *testing.T) {
 						},
 					},
 				},
-				ListMetadata: ListMetadata{
+				ListMetadata: common.ListMetadata{
 					Before: "",
 					After:  "",
 				},
@@ -102,7 +103,7 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 					},
 				},
 			},
-			ListMetadata: ListMetadata{
+			ListMetadata: common.ListMetadata{
 				Before: "",
 				After:  "",
 			},

--- a/pkg/portal/portal.go
+++ b/pkg/portal/portal.go
@@ -1,0 +1,41 @@
+// Package portal is a package to manage the WorkOS Admin Portal
+//
+// You first need to configure your Admin Portal settings at
+// https://dashboard.workos.com/admin-portal.
+//
+// Example:
+//	func main() {
+//		portal.SetAPIKey("my_api_key")
+//
+//		organizations, err := portal.ListOrganizations(
+//			context.Background(),
+//			portal.ListOrganizationsOpts{
+//				Domains: []string{"foo-corp.com"}
+//			},
+//		)
+//	}
+package portal
+
+import (
+	"context"
+)
+
+// DefaultClient is the client used by SetAPIKey and Directory Sync functions.
+var (
+	DefaultClient = &Client{
+		Endpoint: "https://api.workos.com",
+	}
+)
+
+// SetAPIKey sets the WorkOS API key for Directory Sync requests.
+func SetAPIKey(apiKey string) {
+	DefaultClient.APIKey = apiKey
+}
+
+// ListOrganizations gets a list of Organizations.
+func ListOrganizations(
+	ctx context.Context,
+	opts ListOrganizationsOpts,
+) (ListOrganizationsResponse, error) {
+	return DefaultClient.ListOrganizations(ctx, opts)
+}

--- a/pkg/portal/portal_test.go
+++ b/pkg/portal/portal_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/workos-inc/workos-go/pkg/common"
-
 )
 
 func TestPortalListOrganizations(t *testing.T) {

--- a/pkg/portal/portal_test.go
+++ b/pkg/portal/portal_test.go
@@ -1,0 +1,47 @@
+package portal
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortalListOrganizations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listOrganizationsTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := ListOrganizationsResponse{
+		Data: []Organization{
+			Organization{
+				ID:   "organization_id",
+				Name: "Foo Corp",
+				Domains: []OrganizationDomain{
+					OrganizationDomain{
+						ID:     "organization_domain_id",
+						Domain: "foo-corp.com",
+					},
+				},
+			},
+		},
+		ListMetadata: ListMetadata{
+			Before: "",
+			After:  "",
+		},
+	}
+
+	organizationsResponse, err := ListOrganizations(context.Background(), ListOrganizationsOpts{
+		Domains: []string{"foo-corp.com"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, organizationsResponse)
+}

--- a/pkg/portal/portal_test.go
+++ b/pkg/portal/portal_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
+
 )
 
 func TestPortalListOrganizations(t *testing.T) {
@@ -32,7 +34,7 @@ func TestPortalListOrganizations(t *testing.T) {
 				},
 			},
 		},
-		ListMetadata: ListMetadata{
+		ListMetadata: common.ListMetadata{
 			Before: "",
 			After:  "",
 		},


### PR DESCRIPTION
Adds a `portal` package and `ListOrganizations` method to interface with our Admin Portal API.