### PR TITLE
Feature/ch3305/add create organization method to go sdk

### DIFF
--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,6 +29,9 @@ type Client struct {
 	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
 	Endpoint string
 
+	// The function used to encode in JSON. Defaults to json.Marshal.
+	JSONEncode func(v interface{}) ([]byte, error)
+
 	once sync.Once
 }
 
@@ -38,6 +42,10 @@ func (c *Client) init() {
 
 	if c.Endpoint == "" {
 		c.Endpoint = "https://api.workos.com"
+	}
+
+	if c.JSONEncode == nil {
+		c.JSONEncode = json.Marshal
 	}
 }
 
@@ -87,6 +95,15 @@ type ListOrganizationsResponse struct {
 	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
+// CreateOrganizationsOpts contains the options to create an Organization.
+type CreateOrganizationsOpts struct {
+	// Domains of the Organization.
+	Domains []string `json:"domains"`
+
+	// Name of the Organization.
+	Name string `json:"name"`
+}
+
 // ListOrganizations gets a list of WorkOS Organizations.
 func (c *Client) ListOrganizations(
 	ctx context.Context,
@@ -131,6 +148,41 @@ func (c *Client) ListOrganizations(
 	}
 
 	var body ListOrganizationsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// CreateOrganization creates an Organization.
+func (c *Client) CreateOrganization(ctx context.Context, opts CreateOrganizationsOpts) (Organization, error) {
+	c.once.Do(c.init)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return Organization{}, err
+	}
+
+	endpoint := fmt.Sprintf("%s/organizations", c.Endpoint)
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return Organization{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return Organization{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return Organization{}, err
+	}
+
+	var body Organization
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -117,3 +117,111 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
+
+func TestCreateOrganizations(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  CreateOrganizationsOpts
+		expected Organization
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Organization",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: CreateOrganizationsOpts{
+				Name:    "Foo Corp",
+				Domains: []string{"foo-corp.com"},
+			},
+			expected: Organization{
+				ID:   "organization_id",
+				Name: "Foo Corp",
+				Domains: []OrganizationDomain{
+					OrganizationDomain{
+						ID:     "organization_domain_id",
+						Domain: "foo-corp.com",
+					},
+				},
+			},
+		},
+		{
+			scenario: "Request with duplicate Organization Domain returns error",
+			client: &Client{
+				APIKey: "test",
+			},
+			err: true,
+			options: CreateOrganizationsOpts{
+				Name:    "Foo Corp",
+				Domains: []string{"duplicate.com"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(createOrganizationsTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			organization, err := client.CreateOrganization(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, organization)
+		})
+	}
+}
+
+func createOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var opts CreateOrganizationsOpts
+	json.NewDecoder(r.Body).Decode(&opts)
+	for _, domain := range opts.Domains {
+		if domain == "duplicate.com" {
+			http.Error(w, "duplicate domain", http.StatusConflict)
+			return
+		}
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(
+		Organization{
+			ID:   "organization_id",
+			Name: "Foo Corp",
+			Domains: []OrganizationDomain{
+				OrganizationDomain{
+					ID:     "organization_domain_id",
+					Domain: "foo-corp.com",
+				},
+			},
+		})
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/portal/portal.go
+++ b/pkg/portal/portal.go
@@ -39,3 +39,11 @@ func ListOrganizations(
 ) (ListOrganizationsResponse, error) {
 	return DefaultClient.ListOrganizations(ctx, opts)
 }
+
+// CreateOrganization creates an Organization.
+func CreateOrganization(
+	ctx context.Context,
+	opts CreateOrganizationsOpts,
+) (Organization, error) {
+	return DefaultClient.CreateOrganization(ctx, opts)
+}

--- a/pkg/portal/portal_test.go
+++ b/pkg/portal/portal_test.go
@@ -46,3 +46,34 @@ func TestPortalListOrganizations(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, organizationsResponse)
 }
+
+func TestPortalCreateOrganizations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(createOrganizationsTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse :=
+		Organization{
+			ID:   "organization_id",
+			Name: "Foo Corp",
+			Domains: []OrganizationDomain{
+				OrganizationDomain{
+					ID:     "organization_domain_id",
+					Domain: "foo-corp.com",
+				},
+			},
+		}
+
+	organization, err := CreateOrganization(context.Background(), CreateOrganizationsOpts{
+		Name:    "Foo Corp",
+		Domains: []string{"foo-corp.com"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, organization)
+}


### PR DESCRIPTION
Adds a `CreateOrganization` method to interface with our Admin Portal API.