### PR TITLE
Expose `connection_id` on Profile Objects

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v0.5.0"
+	Version = "v0.6.0"
 )

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -154,6 +154,9 @@ type Profile struct {
 	// An unique alphanumeric identifier for a Profile’s identity provider.
 	IdpID string `json:"idp_id"`
 
+	// The connection ID.
+	ConnectionID string `json:"connection_id"`
+	
 	// The connection type.
 	ConnectionType ConnectionType `json:"connection_type"`
 

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -156,7 +156,7 @@ type Profile struct {
 
 	// The connection ID.
 	ConnectionID string `json:"connection_id"`
-	
+
 	// The connection type.
 	ConnectionType ConnectionType `json:"connection_type"`
 

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -110,6 +110,7 @@ func TestClientGetProfile(t *testing.T) {
 			expected: Profile{
 				ID:             "proj_123",
 				IdpID:          "123",
+				ConnectionID:   "conn_123",
 				ConnectionType: OktaSAML,
 				Email:          "foo@test.com",
 				FirstName:      "foo",
@@ -169,6 +170,7 @@ func profileTestHandler(w http.ResponseWriter, r *http.Request) {
 		Profile: Profile{
 			ID:             "proj_123",
 			IdpID:          "123",
+			ConnectionID:   "conn_123",
 			ConnectionType: OktaSAML,
 			Email:          "foo@test.com",
 			FirstName:      "foo",

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -21,6 +21,7 @@ func TestLogin(t *testing.T) {
 	expectedProfile := Profile{
 		ID:             "proj_123",
 		IdpID:          "123",
+		ConnectionID:   "conn_123",
 		ConnectionType: OktaSAML,
 		Email:          "foo@test.com",
 		FirstName:      "foo",


### PR DESCRIPTION
This PR introduces the following changes:
* Passes the `connection_id` Profile object attribute through to the SDK. We currently expose `connection_id` via the `/sso/token` API endpoint.
* Updates the SDK version to `0.6.0`