### PR TITLE
Bump Version to `0.7.0`

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v0.6.0"
+	Version = "v0.7.0"
 )


### PR DESCRIPTION
This PR updates the Go SDK version to `0.7.0` in preparation for the next release.