### PR TITLE
Clean up deprecated RedirectURI from sso.Configure()

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v0.7.0"
+	Version = "v0.8.0"
 )

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -29,7 +29,6 @@ func main() {
     sso.Configure(
         "xxxxx",                            // WorkOS api key
         "project_xxxxx",                    // WorkOS project id
-        "https://mydomain.com/callback",    // Redirect URI
     )
 
     http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -41,12 +41,6 @@ type Client struct {
 	// REQUIRED.
 	ProjectID string
 
-	// The callback URL where your app redirects the user-agent after an
-	// authorization code is granted (eg. https://foo.com/callback).
-	//
-	// Deprecated: Use `GetAuthorizationURLOptions.RedirectURI` instead.
-	RedirectURI string
-
 	// The endpoint to WorkOS API.
 	//
 	// Defaults to https://api.workos.com.
@@ -107,9 +101,6 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 	c.once.Do(c.init)
 
 	redirectURI := opts.RedirectURI
-	if redirectURI == "" {
-		redirectURI = c.RedirectURI
-	}
 
 	query := make(url.Values, 5)
 	query.Set("client_id", c.ProjectID)

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -49,7 +49,7 @@ var (
 // Configure configures the default client that is used by GetAuthorizationURL,
 // GetProfile and Login.
 // It must be called before using those functions.
-func Configure(apiKey, projectID) {
+func Configure(apiKey, projectID string) {
 	DefaultClient.APIKey = apiKey
 	DefaultClient.ProjectID = projectID
 }

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -8,7 +8,6 @@
 //       sso.Configure(
 //           "xxxxx",                         // WorkOS api key
 //           "project_xxxxx",                 // WorkOS project id
-//           "https://mydomain.com/callback", // Redirect URI
 //       )
 //
 //       http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
@@ -50,10 +49,9 @@ var (
 // Configure configures the default client that is used by GetAuthorizationURL,
 // GetProfile and Login.
 // It must be called before using those functions.
-func Configure(apiKey, projectID, redirectURI string) {
+func Configure(apiKey, projectID) {
 	DefaultClient.APIKey = apiKey
 	DefaultClient.ProjectID = projectID
-	DefaultClient.RedirectURI = redirectURI
 }
 
 // GetAuthorizationURL returns an authorization url generated with the given

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -75,7 +75,7 @@ func TestLogin(t *testing.T) {
 		Endpoint:   server.URL,
 		HTTPClient: server.Client(),
 	}
-	Configure("test", "proj_123", redirectURI)
+	Configure("test", "proj_123")
 
 	res, err := server.Client().Get(server.URL + "/login")
 	require.NoError(t, err)


### PR DESCRIPTION
See https://github.com/workos-inc/workos/pull/5525#discussion_r505788145 for related discussion.