### PR TITLE
Update Available Connection Types

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v0.7.0"
+	Version = "v0.8.1"
 )

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -19,13 +19,17 @@ type ConnectionType string
 
 // Constants that enumerate the available connection types.
 const (
-	ADFSSAML     ConnectionType = "ADFSSAML"
-	AzureSAML    ConnectionType = "AzureSAML"
-	GenericSAML  ConnectionType = "GenericSAML"
-	GoogleOAuth  ConnectionType = "GoogleOAuth"
-	OktaSAML     ConnectionType = "OktaSAML"
-	OneLoginSAML ConnectionType = "OneLoginSAML"
-	VMwareSAML   ConnectionType = "VMwareSAML"
+	ADFSSAML         ConnectionType = "ADFSSAML"
+	AzureSAML        ConnectionType = "AzureSAML"
+	GenericOIDC      ConnectionType = "GenericOIDC"
+	GenericSAML      ConnectionType = "GenericSAML"
+	GoogleOAuth      ConnectionType = "GoogleOAuth"
+	MagicLink        ConnectionType = "MagicLink"
+	OktaSAML         ConnectionType = "OktaSAML"
+	OneLoginSAML     ConnectionType = "OneLoginSAML"
+	PingFederateSAML ConnectionType = "PingFederateSAML"
+	PingOneSAML      ConnectionType = "PingOneSAML"
+	VMwareSAML       ConnectionType = "VMwareSAML"
 )
 
 // Client represents a client that fetch SSO data from WorkOS API.


### PR DESCRIPTION
This PR introduces the following changes:

* Updates `ConnectionType` to reflect all Connection Types currently available in GA.
* Updates the SDK version to `0.8.1`.