### PR TITLE
Add Magic Link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Golang SDK to interact with [WorkOS](https://workos.com) APIs.
 - [DirectorySync](https://github.com/workos-inc/workos-go/tree/master/pkg/directorysync)
 - [SSO](https://github.com/workos-inc/workos-go/tree/master/pkg/sso)
 - [Portal](https://github.com/workos-inc/workos-go/tree/master/pkg/portal)
+- [Passwordless](https://github.com/workos-inc/workos-go/tree/master/pkg/passwordless)(i.e. Magic Link)
 
 ## Install
 

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v0.8.1"
+	Version = "v0.9.0"
 )

--- a/pkg/audittrail/audittrail.go
+++ b/pkg/audittrail/audittrail.go
@@ -1,4 +1,4 @@
-// Package audittrail is a package to send audit trail events to WorkOS.
+// Package `audittrail` provides a client wrapping the WorkOS Audit Trail API.
 //
 // Example:
 //   func main() {

--- a/pkg/directorysync/README.md
+++ b/pkg/directorysync/README.md
@@ -12,24 +12,4 @@ go get -u github.com/workos-inc/workos-go/pkg/directorysync
 
 ## How it works
 
-You first need to setup a Directory on [workos.com](https://dashboard.workos.com/directory-sync).
-
-```go
-package main
-
-import "github.com/workos-inc/workos-go/pkg/directorysync"
-
-func main() {
-  directorysync.SetAPIKey("my_api_key")
-
-  directoryUsers, err := directorysync.ListUsers(
-    context.Background(),
-    directorysync.ListUsersOpts{
-      Directory: "directory_id",
-    },
-  )
-  if err != nil {
-      // Handle error.
-  }
-}
-```
+See the [Directory Sync integration guide](https://workos.com/docs/directory-sync/guide).

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -1,20 +1,4 @@
-// Package directorysync is a package to fetch Directory information from
-// WorkOS.
-//
-// You first need to setup a Directory on
-// https://dashboard.workos.com/directory-sync.
-//
-// Example:
-//	func main() {
-//		directorysync.SetAPIKey("my_api_key")
-//
-//		directoryUsers, err := directorysync.ListUsers(
-//			context.Background(),
-//			directorysync.ListUsersOpts{
-//				Directory: "directory_id",
-//			},
-//		)
-//	}
+// Package `directorysync` provides a client wrapping the WorkOS Directory Sync API.
 package directorysync
 
 import (

--- a/pkg/passwordless/README.md
+++ b/pkg/passwordless/README.md
@@ -1,4 +1,4 @@
-# portal
+# passwordless
 
 [![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos-inc/workos-go/pkg/passwordless)
 

--- a/pkg/passwordless/README.md
+++ b/pkg/passwordless/README.md
@@ -1,0 +1,15 @@
+# portal
+
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos-inc/workos-go/pkg/passwordless)
+
+A Go package to make requests to the WorkOS Magic Link API.
+
+## Install
+
+```sh
+go get -u github.com/workos-inc/workos-go/pkg/passwordless
+```
+
+## How it works
+
+See the [Magic Link integration guide](https://workos.com/docs/magic-link/guide).

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -1,4 +1,4 @@
-package package
+package passwordless
 
 import (
 	"bytes"

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -9,9 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-querystring/query"
 	"github.com/workos-inc/workos-go/internal/workos"
-	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 // Client represents a client that performs Passwordless requests to the WorkOS API.
@@ -137,7 +135,7 @@ type SendSessionOpts struct {
 func (c *Client) SendSession(
 	ctx context.Context,
 	opts SendSessionOpts,
-) (string, error) {
+) error {
 	c.once.Do(c.init)
 
 	data, err := c.JSONEncode(opts)

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -96,13 +96,13 @@ func (c *Client) CreateSession(ctx context.Context, opts CreateSessionOpts) (Pas
 
 	data, err := c.JSONEncode(opts)
 	if err != nil {
-		return Organization{}, err
+		return PasswordlessSession{}, err
 	}
 
 	endpoint := fmt.Sprintf("%s/passwordless/sessions", c.Endpoint)
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(data))
 	if err != nil {
-		return Organization{}, err
+		return PasswordlessSession{}, err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -140,7 +140,7 @@ func (c *Client) SendSession(
 
 	data, err := c.JSONEncode(opts)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	endpoint := fmt.Sprintf(
@@ -150,7 +150,7 @@ func (c *Client) SendSession(
 	)
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(data))
 	if err != nil {
-		return "", err
+		return err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
@@ -159,7 +159,7 @@ func (c *Client) SendSession(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer res.Body.Close()
 

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -31,14 +31,14 @@ func TestCreateSession(t *testing.T) {
 				APIKey: "test",
 			},
 			options: CreateSessionOpts{
-				Email:    "sasa@foo-corp.com",
-				Type: MagicLink,
+				Email: "sasa@foo-corp.com",
+				Type:  MagicLink,
 			},
 			expected: PasswordlessSession{
-				ID:   "session_id",
-				Email: "sasa@foo-corp.com",
+				ID:        "session_id",
+				Email:     "sasa@foo-corp.com",
 				ExpiresAt: "",
-				Link: "https://id.workos.test/passwordless/1234/confirm",
+				Link:      "https://id.workos.test/passwordless/1234/confirm",
 			},
 		},
 	}
@@ -80,10 +80,10 @@ func createSessionTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		PasswordlessSession{
-			ID:   "session_id",
-			Email: "sasa@foo-corp.com",
+			ID:        "session_id",
+			Email:     "sasa@foo-corp.com",
 			ExpiresAt: "",
-			Link: "https://id.workos.test/passwordless/1234/confirm",
+			Link:      "https://id.workos.test/passwordless/1234/confirm",
 		})
 
 	if err != nil {

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -83,7 +83,7 @@ func createSessionTestHandler(w http.ResponseWriter, r *http.Request) {
 			ID:   "session_id",
 			Email: "sasa@foo-corp.com",
 			ExpiresAt: "",
-			Link: "https://id.workos.test/passwordless/1234/confirm"
+			Link: "https://id.workos.test/passwordless/1234/confirm",
 		})
 
 	if err != nil {

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -98,7 +98,7 @@ func TestSendSession(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  SendeSessionOpts
+		options  SendSessionOpts
 		expected string
 		err      bool
 	}{

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -1,0 +1,149 @@
+package passwordless
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
+)
+
+func TestCreateSession(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  CreateSessionOpts
+		expected PasswordlessSession
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns PasswordlessSession",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: CreateSessionOpts{
+				Email:    "sasa@foo-corp.com",
+				Type: MagicLink,
+			},
+			expected: PasswordlessSession{
+				ID:   "session_id",
+				Email: "sasa@foo-corp.com",
+				ExpiresAt: "",
+				Link: "https://id.workos.test/passwordless/1234/confirm",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(createSessionTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			session, err := client.CreateSession(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, session)
+		})
+	}
+}
+
+func createSessionTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var opts CreateSessionOpts
+	json.NewDecoder(r.Body).Decode(&opts)
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(
+		PasswordlessSession{
+			ID:   "session_id",
+			Email: "sasa@foo-corp.com",
+			ExpiresAt: "",
+			Link: "https://id.workos.test/passwordless/1234/confirm"
+		})
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestSendSession(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  SendeSessionOpts
+		expected string
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Session is sent",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: SendSessionOpts{
+				ID: "session_id",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(sendSessionTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			link, err := client.SendSession(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func sendSessionTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestCreateSession(t *testing.T) {

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -127,7 +127,7 @@ func TestSendSession(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			link, err := client.SendSession(context.Background(), test.options)
+			err := client.SendSession(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return

--- a/pkg/passwordless/passwordless.go
+++ b/pkg/passwordless/passwordless.go
@@ -1,0 +1,34 @@
+// Package `passwordless` provides a client wrapping the WorkOS Magic Link API.
+package passwordless
+
+import (
+	"context"
+)
+
+// DefaultClient is the client used by the SetAPIKey, CreateSession, and SendSession functions.
+var (
+	DefaultClient = &Client{
+		Endpoint: "https://api.workos.com",
+	}
+)
+
+// SetAPIKey sets the WorkOS API key for Passwordless requests.
+func SetAPIKey(apiKey string) {
+	DefaultClient.APIKey = apiKey
+}
+
+// CreateSession creates a new Passwordless Session
+func CreateSession(
+	ctx context.Context,
+	opts CreateSessionOpts,
+) (PasswordlessSession, error) {
+	return DefaultClient.CreateSession(ctx, opts)
+}
+
+// SendSession sends a Passwordless Session via email
+func SendSession(
+	ctx context.Context,
+	opts SendSessionOpts,
+) error {
+	return DefaultClient.SendSession(ctx, opts)
+}

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -48,6 +48,8 @@ func TestPasswordlessSendSession(t *testing.T) {
 
 	expectedLink := "https://id.workos.test/portal/launch?secret=1234"
 
-	err := SendSession(context.Background(), EventOpts{})
+	err := SendSession(context.Background(), SendSessionOpts{
+		ID: "session_id"
+	})
 	require.NoError(t, err)
 }

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -46,8 +46,6 @@ func TestPasswordlessSendSession(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedLink := "https://id.workos.test/portal/launch?secret=1234"
-
 	err := SendSession(context.Background(), SendSessionOpts{
 		ID: "session_id",
 	})

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/workos-inc/workos-go/pkg/common"
 )
 
-func TestPasswordlessCreateOrganizations(t *testing.T) {
+func TestPasswordlessCreateSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(createSessionTestHandler))
 	defer server.Close()
 

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -1,0 +1,55 @@
+package passwordless
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
+)
+
+func TestPasswordlessCreateOrganizations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(createSessionTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse :=
+		PasswordlessSession{
+			ID:   "organization_id",
+			Email: "sasa@foo-corp.com",
+			ExpiresAt: "",
+			Link: "https://id.workos.test/passwordless/1234/confirm"
+
+		}
+
+	session, err := CreateSession(context.Background(), CreateSessionOpts{
+		Email: "sasa@foo-corp.com",
+		Type: MagicLink,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, session)
+}
+
+func TestPasswordlessSendSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(sendSessionTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedLink := "https://id.workos.test/portal/launch?secret=1234"
+
+	err := SendSession(context.Background(), EventOpts{})
+	require.NoError(t, err)
+}

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -25,7 +25,7 @@ func TestPasswordlessCreateSession(t *testing.T) {
 			ID:   "organization_id",
 			Email: "sasa@foo-corp.com",
 			ExpiresAt: "",
-			Link: "https://id.workos.test/passwordless/1234/confirm"
+			Link: "https://id.workos.test/passwordless/1234/confirm",
 
 		}
 

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -26,7 +26,6 @@ func TestPasswordlessCreateSession(t *testing.T) {
 			Email:     "sasa@foo-corp.com",
 			ExpiresAt: "",
 			Link:      "https://id.workos.test/passwordless/1234/confirm",
-
 		}
 
 	session, err := CreateSession(context.Background(), CreateSessionOpts{

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestPasswordlessCreateSession(t *testing.T) {

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -22,16 +22,16 @@ func TestPasswordlessCreateSession(t *testing.T) {
 
 	expectedResponse :=
 		PasswordlessSession{
-			ID:   "organization_id",
-			Email: "sasa@foo-corp.com",
+			ID:        "organization_id",
+			Email:     "sasa@foo-corp.com",
 			ExpiresAt: "",
-			Link: "https://id.workos.test/passwordless/1234/confirm",
+			Link:      "https://id.workos.test/passwordless/1234/confirm",
 
 		}
 
 	session, err := CreateSession(context.Background(), CreateSessionOpts{
 		Email: "sasa@foo-corp.com",
-		Type: MagicLink,
+		Type:  MagicLink,
 	})
 
 	require.NoError(t, err)

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -49,7 +49,7 @@ func TestPasswordlessSendSession(t *testing.T) {
 	expectedLink := "https://id.workos.test/portal/launch?secret=1234"
 
 	err := SendSession(context.Background(), SendSessionOpts{
-		ID: "session_id"
+		ID: "session_id",
 	})
 	require.NoError(t, err)
 }

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -21,7 +21,7 @@ func TestPasswordlessCreateSession(t *testing.T) {
 
 	expectedResponse :=
 		PasswordlessSession{
-			ID:        "organization_id",
+			ID:        "session_id",
 			Email:     "sasa@foo-corp.com",
 			ExpiresAt: "",
 			Link:      "https://id.workos.test/passwordless/1234/confirm",

--- a/pkg/portal/README.md
+++ b/pkg/portal/README.md
@@ -12,24 +12,4 @@ go get -u github.com/workos-inc/workos-go/pkg/portal
 
 ## How it works
 
-You first need to configure your Admin Portal settings on [workos.com](https://dashboard.workos.com/admin-portal).
-
-```go
-package main
-
-import "github.com/workos-inc/workos-go/pkg/portal"
-
-func main() {
-  portal.SetAPIKey("my_api_key")
-
-  organizations, err := portal.ListOrganizations(
-    context.Background(),
-    portal.ListOrganizationsOpts{
-      Domains: []string{"foo-corp.com"},
-    },
-  )
-  if err != nil {
-      // Handle error.
-  }
-}
-```
+See the [Admin Portal integration guide](https://workos.com/docs/admin-portal/guide).

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -121,8 +121,8 @@ type generateLinkResponse struct {
 	Link string `json:"link"`
 }
 
-// CreateOrganizationsOpts contains the options to create an Organization.
-type CreateOrganizationsOpts struct {
+// CreateOrganizationOpts contains the options to create an Organization.
+type CreateOrganizationOpts struct {
 	// Domains of the Organization.
 	Domains []string `json:"domains"`
 
@@ -180,7 +180,7 @@ func (c *Client) ListOrganizations(
 }
 
 // CreateOrganization creates an Organization.
-func (c *Client) CreateOrganization(ctx context.Context, opts CreateOrganizationsOpts) (Organization, error) {
+func (c *Client) CreateOrganization(ctx context.Context, opts CreateOrganizationOpts) (Organization, error) {
 	c.once.Do(c.init)
 
 	data, err := c.JSONEncode(opts)

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -118,11 +118,11 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestCreateOrganizations(t *testing.T) {
+func TestCreateOrganization(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  CreateOrganizationsOpt
+		options  CreateOrganizationOpt
 		expected Organization
 		err      bool
 	}{
@@ -136,7 +136,7 @@ func TestCreateOrganizations(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: CreateOrganizationsOpt{
+			options: CreateOrganizationOpt{
 				Name:    "Foo Corp",
 				Domains: []string{"foo-corp.com"},
 			},

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -122,7 +122,7 @@ func TestCreateOrganization(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  CreateOrganizationOpt
+		options  CreateOrganizationOpts
 		expected Organization
 		err      bool
 	}{
@@ -136,7 +136,7 @@ func TestCreateOrganization(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: CreateOrganizationOpt{
+			options: CreateOrganizationOpts{
 				Name:    "Foo Corp",
 				Domains: []string{"foo-corp.com"},
 			},

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -166,7 +166,7 @@ func TestCreateOrganization(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(createOrganizationsTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(createOrganizationTestHandler))
 			defer server.Close()
 
 			client := test.client
@@ -184,7 +184,7 @@ func TestCreateOrganization(t *testing.T) {
 	}
 }
 
-func createOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
+func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -122,7 +122,7 @@ func TestCreateOrganizations(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  CreateOrganizationsOpts
+		options  CreateOrganizationsOpt
 		expected Organization
 		err      bool
 	}{
@@ -136,7 +136,7 @@ func TestCreateOrganizations(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: CreateOrganizationsOpts{
+			options: CreateOrganizationsOpt{
 				Name:    "Foo Corp",
 				Domains: []string{"foo-corp.com"},
 			},
@@ -157,7 +157,7 @@ func TestCreateOrganizations(t *testing.T) {
 				APIKey: "test",
 			},
 			err: true,
-			options: CreateOrganizationsOpts{
+			options: CreateOrganizationOpts{
 				Name:    "Foo Corp",
 				Domains: []string{"duplicate.com"},
 			},
@@ -191,7 +191,7 @@ func createOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var opts CreateOrganizationsOpts
+	var opts CreateOrganizationOpts
 	json.NewDecoder(r.Body).Decode(&opts)
 	for _, domain := range opts.Domains {
 		if domain == "duplicate.com" {

--- a/pkg/portal/portal.go
+++ b/pkg/portal/portal.go
@@ -1,33 +1,18 @@
-// Package portal is a package to manage the WorkOS Admin Portal
-//
-// You first need to configure your Admin Portal settings at
-// https://dashboard.workos.com/admin-portal.
-//
-// Example:
-//	func main() {
-//		portal.SetAPIKey("my_api_key")
-//
-//		organizations, err := portal.ListOrganizations(
-//			context.Background(),
-//			portal.ListOrganizationsOpts{
-//				Domains: []string{"foo-corp.com"}
-//			},
-//		)
-//	}
+// Package `portal` provides a client wrapping the WorkOS Admin Portal API.
 package portal
 
 import (
 	"context"
 )
 
-// DefaultClient is the client used by SetAPIKey and Directory Sync functions.
+// DefaultClient is the client used by SetAPIKey and Admin Portal functions.
 var (
 	DefaultClient = &Client{
 		Endpoint: "https://api.workos.com",
 	}
 )
 
-// SetAPIKey sets the WorkOS API key for Directory Sync requests.
+// SetAPIKey sets the WorkOS API key for Admin Portal requests.
 func SetAPIKey(apiKey string) {
 	DefaultClient.APIKey = apiKey
 }
@@ -43,7 +28,7 @@ func ListOrganizations(
 // CreateOrganization creates an Organization.
 func CreateOrganization(
 	ctx context.Context,
-	opts CreateOrganizationsOpts,
+	opts CreateOrganizationOpts,
 ) (Organization, error) {
 	return DefaultClient.CreateOrganization(ctx, opts)
 }

--- a/pkg/portal/portal_test.go
+++ b/pkg/portal/portal_test.go
@@ -69,7 +69,7 @@ func TestPortalCreateOrganizations(t *testing.T) {
 			},
 		}
 
-	organization, err := CreateOrganization(context.Background(), CreateOrganizationsOpts{
+	organization, err := CreateOrganization(context.Background(), CreateOrganizationOpts{
 		Name:    "Foo Corp",
 		Domains: []string{"foo-corp.com"},
 	})

--- a/pkg/portal/portal_test.go
+++ b/pkg/portal/portal_test.go
@@ -47,8 +47,8 @@ func TestPortalListOrganizations(t *testing.T) {
 	require.Equal(t, expectedResponse, organizationsResponse)
 }
 
-func TestPortalCreateOrganizations(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(createOrganizationsTestHandler))
+func TestPortalCreateOrganization(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(createOrganizationTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -12,45 +12,4 @@ go get -u github.com/workos-inc/workos-go/pkg/sso
 
 ## How it works
 
-You first need to setup an SSO connection on [workos.com](https://dashboard.workos.com/sso/connections).
-
-Then implement the `/login` and `/callback` handlers on your server:
-
-```go
-import (
-    "context"
-    "fmt"
-    "net/http"
-
-    "github.com/workos-inc/workos-go/pkg/sso"
-)
-
-func main() {
-    sso.Configure(
-        "xxxxx",                            // WorkOS api key
-        "project_xxxxx",                    // WorkOS project id
-    )
-
-    http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
-        Domain: "mydomain.com",
-        RedirectURI: "https://mydomain.com/callback",
-    }))
-
-    http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-        profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
-            Code:   r.URL.Query().Get("code"),
-        })
-        if err != nil {
-            // Handle the error ...
-            return
-        }
-
-        // Handle the profile ...
-        fmt.Println(profile)
-    })
-
-    if err := http.ListenAndServe("your_server_addr", nil); err != nil {
-        panic(err)
-    }
-}
-```
+See the [SSO integration guide](https://workos.com/docs/sso/guide).

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -141,7 +141,7 @@ type GetProfileOptions struct {
 	Code string
 }
 
-// Profile contains information about a user authentication.
+// Profile contains information about an authenticated user.
 type Profile struct {
 	// The user ID.
 	ID string `json:"id"`

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -1,37 +1,4 @@
-// Package sso provide functions and client to communicate with WorkOS SSO API.
-//
-// You first need to setup an SSO connection on
-// https://dashboard.workos.com/sso/connections.
-//
-// Then implement the `/login` and `/callback` handlers on your server:
-//   func main() {
-//       sso.Configure(
-//           "xxxxx",                         // WorkOS api key
-//           "project_xxxxx",                 // WorkOS project id
-//       )
-//
-//       http.Handle("/login", sso.Login(sso.GetAuthorizationURLOptions{
-//           Domain:	"mydomain.com",
-//           RedirectURI: "https://mydomain.com/callback",
-//       }))
-//
-//       http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-//           profile, err := sso.GetProfile(context.Background(), sso.GetProfileOptions{
-//               Code:	r.URL.Query().Get("code"),
-//           })
-//           if err != nil {
-//               // Handle the error ...
-//               return
-//           }
-//
-//           // Handle the profile ...
-//           fmt.Println(profile)
-//       })
-//
-//       if err := http.ListenAndServe("your_server_addr", nil); err != nil {
-//           panic(err)
-//       }
-//   }
+// Package `sso` provides a client wrapping the WorkOS SSO API.
 package sso
 
 import (


### PR DESCRIPTION
- Adds `passwordless` package to support WorkOS Magic Link operations.
```go
passwordless.CreateSession(context.Background(), passwordless.CreateSessionOpts{
	Email: "foo@bar.com",
        Type: passwordless.MagicLink,
})

passwordless.SendSession(context.Background(), passwordless.SendSessionOpts{
        ID: "session_id",
})
```
- Updates `CreateOrganizationsOpts` --> `CreateOrganizationOpts`.
- Bumps version.
- Cleans up docstrings and READMEs to encourage referencing https://workos.com/docs
