### PR TITLE
Add `GET /connections`

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -5,14 +5,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/workos-inc/workos-go/internal/workos"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
+
+// ResponseLimit is the default number of records to limit a response to.
+const ResponseLimit = 10
 
 // ConnectionType represents a connection type.
 type ConnectionType string
@@ -353,6 +359,84 @@ func (c *Client) CreateConnection(ctx context.Context, opts CreateConnectionOpts
 	}
 
 	var body Connection
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// ListConnectionsOpts contains the options to request a list of Connections.
+type ListConnectionsOpts struct {
+	// Authentication service provider descriptor. Can be empty.
+	ConnectionType ConnectionType
+
+	// Domain of a Connection. Can be empty.
+	Domain string
+
+	// Maximum number of records to return.
+	Limit int
+
+	// Pagination cursor to receive records before a provided Connection ID.
+	Before string
+
+	// Pagination cursor to receive records after a provided Connection ID.
+	After string
+}
+
+// ListConnectionsResponse describes the response structure when requesting
+// existing Connections.
+type ListConnectionsResponse struct {
+	// List of Connections
+	Data []Connection `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata common.ListMetadata `json:"listMetadata"`
+}
+
+// ListConnections gets details of existing Connections.
+func (c *Client) ListConnections(
+	ctx context.Context,
+	opts ListConnectionsOpts,
+) (ListConnectionsResponse, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf("%s/connections", c.Endpoint)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListConnectionsResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	limit := ResponseLimit
+	if opts.Limit != 0 {
+		limit = opts.Limit
+	}
+	q := req.URL.Query()
+	q.Add("before", opts.Before)
+	q.Add("after", opts.After)
+	q.Add("connection_type", string(opts.ConnectionType))
+	q.Add("domain", opts.Domain)
+	q.Add("Limit", strconv.Itoa(limit))
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListConnectionsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return ListConnectionsResponse{}, err
+	}
+
+	var body ListConnectionsResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestClientAuthorizeURL(t *testing.T) {
@@ -371,4 +372,46 @@ func createConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusCreated)
 	w.Write(connection)
+}
+
+func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth:= r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(ListConnectionsResponse{
+		Data: []Connection{
+			Connection{
+				ID:   "conn_id",
+				 ConnectionType: "GoogleOAuth",
+				 Name: "Foo Corp",
+				 OAuthRedirectURI: "uri",
+				 OAuthSecret: "secret",
+				 OAuthUID: "uid",
+				 SamlEntityID: "null",
+				 SamlIDPURL: "null",
+				 SamlRelyingPartyTrustCert: "null",
+				 SamlX509Certs: []string{},
+				 Status: "linked",
+			},
+		},
+			ListMetadata: common.ListMetadata{
+				Before: "",
+				After:  "",
+			},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
 }

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -375,7 +375,7 @@ func createConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
-	auth:= r.Header.Get("Authorization")
+	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
 		return
@@ -389,23 +389,23 @@ func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := json.Marshal(ListConnectionsResponse{
 		Data: []Connection{
 			Connection{
-				ID:   "conn_id",
-				 ConnectionType: "GoogleOAuth",
-				 Name: "Foo Corp",
-				 OAuthRedirectURI: "uri",
-				 OAuthSecret: "secret",
-				 OAuthUID: "uid",
-				 SamlEntityID: "null",
-				 SamlIDPURL: "null",
-				 SamlRelyingPartyTrustCert: "null",
-				 SamlX509Certs: []string{},
-				 Status: "linked",
+				ID:                        "conn_id",
+				ConnectionType:            "GoogleOAuth",
+				Name:                      "Foo Corp",
+				OAuthRedirectURI:          "uri",
+				OAuthSecret:               "secret",
+				OAuthUID:                  "uid",
+				SamlEntityID:              "null",
+				SamlIDPURL:                "null",
+				SamlRelyingPartyTrustCert: "null",
+				SamlX509Certs:             []string{},
+				Status:                    "linked",
 			},
 		},
-			ListMetadata: common.ListMetadata{
-				Before: "",
-				After:  "",
-			},
+		ListMetadata: common.ListMetadata{
+			Before: "",
+			After:  "",
+		},
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -61,3 +61,11 @@ func PromoteDraftConnection(ctx context.Context, opts PromoteDraftConnectionOpti
 func CreateConnection(ctx context.Context, opts CreateConnectionOpts) (Connection, error) {
 	return DefaultClient.CreateConnection(ctx, opts)
 }
+
+// ListConnections gets a list of existing Connections.
+func ListConnections(
+	ctx context.Context,
+	opts ListConnectionsOpts,
+) (ListConnectionsResponse, error) {
+	return DefaultClient.ListConnections(ctx, opts)
+}

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -87,7 +87,7 @@ func TestLogin(t *testing.T) {
 	require.Equal(t, expectedProfile, profile)
 }
 
-func TestListConnections(t *testing.T) {
+func TestSsoListConnections(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(listConnectionsTestHandler))
 	defer server.Close()
 

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -88,41 +88,41 @@ func TestLogin(t *testing.T) {
 }
 
 func TestListConnections(t *testing.T) {
-	 server := httptest.NewServer(http.HandlerFunc(listConnectionsTestHandler))
-	 defer server.Close()
+	server := httptest.NewServer(http.HandlerFunc(listConnectionsTestHandler))
+	defer server.Close()
 
-	 DefaultClient = &Client{
-		 HTTPClient: server.Client(),
-		 Endpoint:   server.URL,
-	 }
-	 Configure("test", "client_123")
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	Configure("test", "client_123")
 
-	 expectedResponse := ListConnectionsResponse{
-		 Data: []Connection{
-			 Connection{
-				 ID:   "conn_id",
-				 ConnectionType: "GoogleOAuth",
-				 Name: "Foo Corp",
-				 OAuthRedirectURI: "uri",
-				 OAuthSecret: "secret",
-				 OAuthUID: "uid",
-				 SamlEntityID: "null",
-				 SamlIDPURL: "null",
-				 SamlRelyingPartyTrustCert: "null",
-				 SamlX509Certs: []string{},
-				 Status: "linked",
-			 },
+	expectedResponse := ListConnectionsResponse{
+		Data: []Connection{
+			Connection{
+				ID:                        "conn_id",
+				ConnectionType:            "GoogleOAuth",
+				Name:                      "Foo Corp",
+				OAuthRedirectURI:          "uri",
+				OAuthSecret:               "secret",
+				OAuthUID:                  "uid",
+				SamlEntityID:              "null",
+				SamlIDPURL:                "null",
+				SamlRelyingPartyTrustCert: "null",
+				SamlX509Certs:             []string{},
+				Status:                    "linked",
 			},
-			 ListMetadata: common.ListMetadata{
-				 Before: "",
-				 After:  "",
-			 },
-	 }
-	 connectionsResponse, err := ListConnections(
-		 context.Background(),
-		 ListConnectionsOpts{},
-	 )
+		},
+		ListMetadata: common.ListMetadata{
+			Before: "",
+			After:  "",
+		},
+	}
+	connectionsResponse, err := ListConnections(
+		context.Background(),
+		ListConnectionsOpts{},
+	)
 
-	 require.NoError(t, err)
-	 require.Equal(t, expectedResponse, connectionsResponse)
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, connectionsResponse)
 }

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/workos-inc/workos-go/pkg/common"
 )
 
 func TestLogin(t *testing.T) {
@@ -84,4 +85,44 @@ func TestLogin(t *testing.T) {
 
 	wg.Wait()
 	require.Equal(t, expectedProfile, profile)
+}
+
+func TestListConnections(t *testing.T) {
+	 server := httptest.NewServer(http.HandlerFunc(listConnectionsTestHandler))
+	 defer server.Close()
+
+	 DefaultClient = &Client{
+		 HTTPClient: server.Client(),
+		 Endpoint:   server.URL,
+	 }
+	 Configure("test", "client_123")
+
+	 expectedResponse := ListConnectionsResponse{
+		 Data: []Connection{
+			 Connection{
+				 ID:   "conn_id",
+				 ConnectionType: "GoogleOAuth",
+				 Name: "Foo Corp",
+				 OAuthRedirectURI: "uri",
+				 OAuthSecret: "secret",
+				 OAuthUID: "uid",
+				 SamlEntityID: "null",
+				 SamlIDPURL: "null",
+				 SamlRelyingPartyTrustCert: "null",
+				 SamlX509Certs: []string{},
+				 Status: "linked",
+			 },
+			},
+			 ListMetadata: common.ListMetadata{
+				 Before: "",
+				 After:  "",
+			 },
+	 }
+	 connectionsResponse, err := ListConnections(
+		 context.Background(),
+		 ListConnectionsOpts{},
+	 )
+
+	 require.NoError(t, err)
+	 require.Equal(t, expectedResponse, connectionsResponse)
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to retrieve a list of Connections using the WorkOS SSO REST API