### PR TITLE
Add `GET /connections/:id`

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -340,6 +341,54 @@ func (c *Client) CreateConnection(ctx context.Context, opts CreateConnectionOpts
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return Connection{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos.TryGetHTTPError(res); err != nil {
+		return Connection{}, err
+	}
+
+	var body Connection
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+
+// GetConnectionOpts contains the options to request details for a Connection.
+type GetConnectionOpts struct {
+	// Connection unique identifier.
+	Connection string
+}
+
+// GetConnection gets a Connection.
+func (c *Client) GetConnection(
+	ctx context.Context,
+	opts GetConnectionOpts,
+) (Connection, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf(
+		"%s/connections/%s",
+		c.Endpoint,
+		opts.Connection,
+	)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return Connection{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
 
 	res, err := c.HTTPClient.Do(req)

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -372,3 +372,89 @@ func createConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	w.Write(connection)
 }
+
+func TestGetConnection(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetConnectionOpts
+		expected Connection
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns a Connection",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetConnectionOpts{
+				Connection: "connection_id",
+			},
+			expected: Connection{
+				ID:                        "conn_id",
+				ConnectionType:            "GoogleOAuth",
+				Name:                      "Foo Corp",
+				OAuthRedirectURI:          "uri",
+				OAuthSecret:               "secret",
+				OAuthUID:                  "uid",
+				SamlEntityID:              "null",
+				SamlIDPURL:                "null",
+				SamlRelyingPartyTrustCert: "null",
+				SamlX509Certs:             []string{},
+				Status:                    "linked",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getConnectionTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			connection, err := client.GetConnection(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, connection)
+		})
+	}
+}
+
+func getConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := json.Marshal(Connection{
+		ID:                        "conn_id",
+		ConnectionType:            "GoogleOAuth",
+		Name:                      "Foo Corp",
+		OAuthRedirectURI:          "uri",
+		OAuthSecret:               "secret",
+		OAuthUID:                  "uid",
+		SamlEntityID:              "null",
+		SamlIDPURL:                "null",
+		SamlRelyingPartyTrustCert: "null",
+		SamlX509Certs:             []string{},
+		Status:                    "linked",
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -61,3 +61,10 @@ func PromoteDraftConnection(ctx context.Context, opts PromoteDraftConnectionOpti
 func CreateConnection(ctx context.Context, opts CreateConnectionOpts) (Connection, error) {
 	return DefaultClient.CreateConnection(ctx, opts)
 }
+
+func GetConnection(
+	ctx context.Context,
+	opts GetConnectionOpts,
+) (Connection, error) {
+	return DefaultClient.GetConnection(ctx, opts)
+}

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -85,3 +85,34 @@ func TestLogin(t *testing.T) {
 	wg.Wait()
 	require.Equal(t, expectedProfile, profile)
 }
+
+func TestSsoGetConnection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getConnectionTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	Configure("test", "client_123")
+
+	expectedResponse := Connection{
+		ID:                        "conn_id",
+		ConnectionType:            "GoogleOAuth",
+		Name:                      "Foo Corp",
+		OAuthRedirectURI:          "uri",
+		OAuthSecret:               "secret",
+		OAuthUID:                  "uid",
+		SamlEntityID:              "null",
+		SamlIDPURL:                "null",
+		SamlRelyingPartyTrustCert: "null",
+		SamlX509Certs:             []string{},
+		Status:                    "linked",
+	}
+	connectionResponse, err := GetConnection(context.Background(), GetConnectionOpts{
+		Connection: "connection_id",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, connectionResponse)
+}


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to retrieve a single Connection using the WorkOS SSO REST API