### PR TITLE
Decode Org ID from Connection API responses

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -300,6 +300,9 @@ type Connection struct {
 	// Connection provider type.
 	ConnectionType ConnectionType `json:"connection_type"`
 
+	// Organization ID.
+	OrganizationID string `json:"organization_id"`
+
 	// OAuth Client ID.
 	OAuthUID string `json:"oauth_uid"`
 


### PR DESCRIPTION
We want to get org ID from the GetConnection and ListConnection APIs, and they do return it, but the struct that the response is decoded into did not include it.