### PR TITLE
Add `DELETE /connections/:id`

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -489,3 +489,44 @@ func (c *Client) ListConnections(
 	err = dec.Decode(&body)
 	return body, err
 }
+
+// DeleteConnectionOpts contains the options to delete a Connection.
+type DeleteConnectionOpts struct {
+	// Connection unique identifier.
+	Connection string
+}
+
+// DeleteConnection deletes a Connection.
+func (c *Client) DeleteConnection(
+	ctx context.Context,
+	opts DeleteConnectionOpts,
+) (error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf(
+		"%s/connections/%s",
+		c.Endpoint,
+		opts.Connection,
+	)
+	req, err := http.NewRequest(
+		http.MethodDelete,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	return workos.TryGetHTTPError(res)
+}

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -503,7 +503,7 @@ type DeleteConnectionOpts struct {
 func (c *Client) DeleteConnection(
 	ctx context.Context,
 	opts DeleteConnectionOpts,
-) (error) {
+) error {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf(

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -78,6 +78,7 @@ func ListConnections(
 	return DefaultClient.ListConnections(ctx, opts)
 }
 
+// DeleteConnection deletes a Connection.
 func DeleteConnection(
 	ctx context.Context,
 	opts DeleteConnectionOpts,

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -62,6 +62,7 @@ func CreateConnection(ctx context.Context, opts CreateConnectionOpts) (Connectio
 	return DefaultClient.CreateConnection(ctx, opts)
 }
 
+// GetConnection gets a Connection.
 func GetConnection(
 	ctx context.Context,
 	opts GetConnectionOpts,
@@ -75,4 +76,11 @@ func ListConnections(
 	opts ListConnectionsOpts,
 ) (ListConnectionsResponse, error) {
 	return DefaultClient.ListConnections(ctx, opts)
+}
+
+func DeleteConnection(
+	ctx context.Context,
+	opts DeleteConnectionOpts,
+) error {
+	return DefaultClient.DeleteConnection(ctx, opts)
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to delete a single Connection using the WorkOS SSO REST API