### PR TITLE
ListConnections: fix mispelt limit query param

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -489,7 +489,7 @@ func (c *Client) ListConnections(
 		q.Add("connection_type", string(opts.ConnectionType))
 	}
 	q.Add("domain", opts.Domain)
-	q.Add("Limit", strconv.Itoa(limit))
+	q.Add("limit", strconv.Itoa(limit))
 	req.URL.RawQuery = q.Encode()
 
 	res, err := c.HTTPClient.Do(req)


### PR DESCRIPTION
It was only working as `limit`. I assume just a spelling mistake.