### PR TITLE
ListConnections: Add org ID filter option

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -433,6 +433,9 @@ type ListConnectionsOpts struct {
 	// Authentication service provider descriptor. Can be empty.
 	ConnectionType ConnectionType
 
+	// Organization ID of the Connection(s). Can be empty.
+	OrganizationID string
+
 	// Domain of a Connection. Can be empty.
 	Domain string
 
@@ -488,6 +491,7 @@ func (c *Client) ListConnections(
 	if opts.ConnectionType != "" {
 		q.Add("connection_type", string(opts.ConnectionType))
 	}
+	q.Add("organization_id", string(opts.OrganizationID))
 	q.Add("domain", opts.Domain)
 	q.Add("Limit", strconv.Itoa(limit))
 	req.URL.RawQuery = q.Encode()


### PR DESCRIPTION
The API seems to already support this, so this PR just adds it as a usable option to the ListConnections API:

![Screenshot 2021-02-02 at 14 38 56](https://user-images.githubusercontent.com/5685776/106619477-8bb79300-6568-11eb-9412-df89f67f7cd1.png)
