### PR TITLE
ListConnections: only use type filter if non-empty

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -485,7 +485,9 @@ func (c *Client) ListConnections(
 	q := req.URL.Query()
 	q.Add("before", opts.Before)
 	q.Add("after", opts.After)
-	q.Add("connection_type", string(opts.ConnectionType))
+	if opts.ConnectionType != "" {
+		q.Add("connection_type", string(opts.ConnectionType))
+	}
 	q.Add("domain", opts.Domain)
 	q.Add("Limit", strconv.Itoa(limit))
 	req.URL.RawQuery = q.Encode()


### PR DESCRIPTION
Otherwise the server responds with a 422 error:
![Screenshot 2021-02-02 at 15 50 22](https://user-images.githubusercontent.com/5685776/106626706-e3a5c800-656f-11eb-8ac6-f9ee584a2132.png)

Maybe this is a server issue (should ignore the type param if empty), like it seems to do for the other empty params, but this fixes the issue so the API can be used through the SDK ASAP.