### PR TITLE
Remove Unneeded Attribute from `Directory` Struct

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -379,9 +379,6 @@ type Directory struct {
 	// Externally used identifier for the Directory.
 	ExternalKey string `json:"external_key"`
 
-	// Bearer Token used to authenticate requests.
-	BearerToken string `json:"bearer_token"`
-
 	// Identifier for the Directory's Environment.
 	EnvironmentID string `json:"environment_id"`
 


### PR DESCRIPTION
This PR introduces the following changes:

* Removes `bearer_token` attribute from `Directory` struct