### PR TITLE
Add `OrganizationID` Option to `ListConnections`

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -436,6 +436,9 @@ type ListConnectionsOpts struct {
 	// Domain of a Connection. Can be empty.
 	Domain string
 
+	// Unique identifier of an Organization. Can be empty.
+	OrganizationID string
+
 	// Maximum number of records to return.
 	Limit int
 


### PR DESCRIPTION
This PR introduces the following changes:

- Adds support for an `OrganizationID` option to the `ListConnections` function. Allows for retrieving a list of all Connections associated with the given `OrganizationID`.