### PR TITLE
feat(workos-go): Add field for Directory User state

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -53,6 +53,15 @@ type UserEmail struct {
 	Type string
 }
 
+// UserState represents the active state of a Directory User.
+type UserState string
+
+// Constants that enumerate the state of a Directory User.
+const (
+	Active    UserState = "active"
+	Suspended UserState = "suspended"
+)
+
 // User contains data about a provisioned Directory User.
 type User struct {
 	// The User's unique identifier.
@@ -69,6 +78,9 @@ type User struct {
 
 	// The User's last name.
 	LastName string `json:"last_name"`
+
+	// The User's state.
+	State UserState `json:"state"`
 
 	// The User's raw attributes in raw encoded JSON.
 	RawAttributes json.RawMessage `json:"raw_attributes"`

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -36,7 +36,7 @@ func TestListUsers(t *testing.T) {
 			expected: ListUsersResponse{
 				Data: []User{
 					User{
-						ID:        "directory_usr_id",
+						ID:        "directory_user_id",
 						FirstName: "Rick",
 						LastName:  "Sanchez",
 						Emails: []UserEmail{
@@ -46,6 +46,7 @@ func TestListUsers(t *testing.T) {
 								Value:   "rick@sanchez.com",
 							},
 						},
+						State:         Active,
 						RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 					},
 				},
@@ -95,7 +96,7 @@ func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListUsersResponse: ListUsersResponse{
 			Data: []User{
 				User{
-					ID:        "directory_usr_id",
+					ID:        "directory_user_id",
 					FirstName: "Rick",
 					LastName:  "Sanchez",
 					Emails: []UserEmail{
@@ -105,6 +106,7 @@ func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 							Value:   "rick@sanchez.com",
 						},
 					},
+					State:         Active,
 					RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 				},
 			},
@@ -147,7 +149,7 @@ func TestListGroups(t *testing.T) {
 			expected: ListGroupsResponse{
 				Data: []Group{
 					Group{
-						ID:   "directory_grp_id",
+						ID:   "directory_group_id",
 						Name: "Scientists",
 					},
 				},
@@ -197,7 +199,7 @@ func listGroupsTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListGroupsResponse: ListGroupsResponse{
 			Data: []Group{
 				Group{
-					ID:   "directory_grp_id",
+					ID:   "directory_group_id",
 					Name: "Scientists",
 				},
 			},
@@ -235,10 +237,10 @@ func TestGetUser(t *testing.T) {
 				APIKey: "test",
 			},
 			options: GetUserOpts{
-				User: "directory_usr_id",
+				User: "directory_user_id",
 			},
 			expected: User{
-				ID:        "directory_usr_id",
+				ID:        "directory_user_id",
 				FirstName: "Rick",
 				LastName:  "Sanchez",
 				Emails: []UserEmail{
@@ -248,6 +250,7 @@ func TestGetUser(t *testing.T) {
 						Value:   "rick@sanchez.com",
 					},
 				},
+				State:         Active,
 				RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 			},
 		},
@@ -286,7 +289,7 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(User{
-		ID:        "directory_usr_id",
+		ID:        "directory_user_id",
 		FirstName: "Rick",
 		LastName:  "Sanchez",
 		Emails: []UserEmail{
@@ -296,6 +299,7 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 				Value:   "rick@sanchez.com",
 			},
 		},
+		State:         Active,
 		RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 	})
 	if err != nil {
@@ -326,10 +330,10 @@ func TestGetGroup(t *testing.T) {
 				APIKey: "test",
 			},
 			options: GetGroupOpts{
-				Group: "directory_grp_id",
+				Group: "directory_group_id",
 			},
 			expected: Group{
-				ID:   "directory_grp_id",
+				ID:   "directory_group_id",
 				Name: "Scientists",
 			},
 		},
@@ -368,7 +372,7 @@ func getGroupTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Group{
-		ID:   "directory_grp_id",
+		ID:   "directory_group_id",
 		Name: "Scientists",
 	})
 	if err != nil {

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -24,7 +24,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 	expectedResponse := ListUsersResponse{
 		Data: []User{
 			User{
-				ID:        "directory_usr_id",
+				ID:        "directory_user_id",
 				FirstName: "Rick",
 				LastName:  "Sanchez",
 				Emails: []UserEmail{
@@ -34,6 +34,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 						Value:   "rick@sanchez.com",
 					},
 				},
+				State:         Active,
 				RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 			},
 		},
@@ -63,7 +64,7 @@ func TestDirectorySyncListGroups(t *testing.T) {
 	expectedResponse := ListGroupsResponse{
 		Data: []Group{
 			Group{
-				ID:   "directory_grp_id",
+				ID:   "directory_group_id",
 				Name: "Scientists",
 			},
 		},
@@ -94,7 +95,7 @@ func TestDirectorySyncGetUser(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := User{
-		ID:        "directory_usr_id",
+		ID:        "directory_user_id",
 		FirstName: "Rick",
 		LastName:  "Sanchez",
 		Emails: []UserEmail{
@@ -104,10 +105,11 @@ func TestDirectorySyncGetUser(t *testing.T) {
 				Value:   "rick@sanchez.com",
 			},
 		},
+		State:         Active,
 		RawAttributes: json.RawMessage(`{"foo":"bar"}`),
 	}
 	directoryUserResponse, err := GetUser(context.Background(), GetUserOpts{
-		User: "directory_usr_id",
+		User: "directory_user_id",
 	})
 
 	require.NoError(t, err)
@@ -125,11 +127,11 @@ func TestDirectorySyncGetGroup(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Group{
-		ID:   "directory_grp_id",
+		ID:   "directory_group_id",
 		Name: "Scientists",
 	}
 	directoryGroupResponse, err := GetGroup(context.Background(), GetGroupOpts{
-		Group: "directory_grp_id",
+		Group: "directory_group_id",
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
Return a field which indicates if a User is active or suspended.