### PR TITLE
Add `InvalidCredentials` to `DirectoryState` Type

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -373,8 +373,9 @@ type DirectoryState string
 
 // Constants that enumerate the linked status of a Directory.
 const (
-	Linked   DirectoryState = "linked"
-	Unlinked DirectoryState = "unlinked"
+	Linked             DirectoryState = "linked"
+	Unlinked           DirectoryState = "unlinked"
+	InvalidCredentials DirectoryState = "invalid_credentials"
 )
 
 // Directory contains data about a project's directory.


### PR DESCRIPTION
This PR introduces the following changes:

- Adds `InvalidCredentials` as a possible value for the `DirectoryState` type. This reflects the most up-to-date, available values for the Directory state enum provided by the WorkOS API.