### PR TITLE
expose idp_id for directory users in Go SDK

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -400,6 +400,9 @@ type Directory struct {
 
 	// Linked status for the Directory.
 	State DirectoryState `json:"state"`
+
+ // The user's directory provider's Identifier
+	IdpID string `json:"idp_id"`
 }
 
 // ListDirectoriesOpts contains the options to request a Project's Directories.

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -401,7 +401,7 @@ type Directory struct {
 	// Linked status for the Directory.
 	State DirectoryState `json:"state"`
 
- // The user's directory provider's Identifier
+	// The user's directory provider's Identifier
 	IdpID string `json:"idp_id"`
 }
 


### PR DESCRIPTION
PR to add the idp_id into the Directory structure to expose it.