### PR TITLE
Remove deprecated Connection fields

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -324,27 +324,6 @@ type Connection struct {
 	// Organization ID.
 	OrganizationID string `json:"organization_id"`
 
-	// OAuth Client ID.
-	OAuthUID string `json:"oauth_uid"`
-
-	// OAuth Client Secret.
-	OAuthSecret string `json:"oauth_secret"`
-
-	// OAuth Client Redirect URI.
-	OAuthRedirectURI string `json:"oauth_redirect_uri"`
-
-	// Identity Provider Issuer.
-	SamlEntityID string `json:"saml_entity_id"`
-
-	// Identity Provider SSO URL.
-	SamlIDPURL string `json:"saml_idp_url"`
-
-	// Certificate that describes where to expect valid SAML claims to come from.
-	SamlRelyingPartyTrustCert string `json:"saml_relying_party_trust_cert"`
-
-	// Certificates used to authenticate SAML assertions.
-	SamlX509Certs []string `json:"saml_x509_certs"`
-
 	// Domain records for the Connection.
 	Domains []ConnectionDomain `json:"domains"`
 }

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -303,11 +303,11 @@ func TestClientCreateConnection(t *testing.T) {
 				Source: "source",
 			},
 			expected: Connection{
-				ID:                        "connection",
-				Name:                      "Terrace House",
-				ConnectionType:            OktaSAML,
-				State:                     Inactive,
-				Status:                    Unlinked,
+				ID:             "connection",
+				Name:           "Terrace House",
+				ConnectionType: OktaSAML,
+				State:          Inactive,
+				Status:         Unlinked,
 			},
 			err: false,
 		},
@@ -351,11 +351,11 @@ func createConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	connection, err := json.Marshal(Connection{
-		ID:                        "connection",
-		Name:                      "Terrace House",
-		ConnectionType:            OktaSAML,
-		State:                     Inactive,
-		Status:                    Unlinked,
+		ID:             "connection",
+		Name:           "Terrace House",
+		ConnectionType: OktaSAML,
+		State:          Inactive,
+		Status:         Unlinked,
 	})
 
 	if err != nil {
@@ -389,11 +389,11 @@ func TestGetConnection(t *testing.T) {
 				Connection: "connection_id",
 			},
 			expected: Connection{
-				ID:                        "conn_id",
-				ConnectionType:            "GoogleOAuth",
-				State:                     Active,
-				Status:                    Linked,
-				Name:                      "Foo Corp",
+				ID:             "conn_id",
+				ConnectionType: "GoogleOAuth",
+				State:          Active,
+				Status:         Linked,
+				Name:           "Foo Corp",
 			},
 		},
 	}
@@ -426,11 +426,11 @@ func getConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Connection{
-		ID:                        "conn_id",
-		ConnectionType:            "GoogleOAuth",
-		State:                     Active,
-		Status:                    Linked,
-		Name:                      "Foo Corp",
+		ID:             "conn_id",
+		ConnectionType: "GoogleOAuth",
+		State:          Active,
+		Status:         Linked,
+		Name:           "Foo Corp",
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -463,11 +463,11 @@ func TestListConnections(t *testing.T) {
 			expected: ListConnectionsResponse{
 				Data: []Connection{
 					Connection{
-						ID:                        "conn_id",
-						ConnectionType:            "GoogleOAuth",
-						State:                     Active,
-						Status:                    Linked,
-						Name:                      "Foo Corp",
+						ID:             "conn_id",
+						ConnectionType: "GoogleOAuth",
+						State:          Active,
+						Status:         Linked,
+						Name:           "Foo Corp",
 					},
 				},
 				ListMetadata: common.ListMetadata{
@@ -513,11 +513,11 @@ func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := json.Marshal(ListConnectionsResponse{
 		Data: []Connection{
 			Connection{
-				ID:                        "conn_id",
-				ConnectionType:            "GoogleOAuth",
-				State:                     Active,
-				Status:                    Linked,
-				Name:                      "Foo Corp",
+				ID:             "conn_id",
+				ConnectionType: "GoogleOAuth",
+				State:          Active,
+				Status:         Linked,
+				Name:           "Foo Corp",
 			},
 		},
 		ListMetadata: common.ListMetadata{

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -308,15 +308,6 @@ func TestClientCreateConnection(t *testing.T) {
 				ConnectionType:            OktaSAML,
 				State:                     Inactive,
 				Status:                    Unlinked,
-				OAuthUID:                  "",
-				OAuthSecret:               "",
-				OAuthRedirectURI:          "",
-				SamlEntityID:              "http://www.okta.com/rijeonghyeok",
-				SamlIDPURL:                "https://foo.okta.com/app/fried/chicken/sso/saml",
-				SamlRelyingPartyTrustCert: "",
-				SamlX509Certs: []string{
-					"-----BEGIN CERTIFICATE----------END CERTIFICATE-----",
-				},
 			},
 			err: false,
 		},
@@ -365,15 +356,6 @@ func createConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 		ConnectionType:            OktaSAML,
 		State:                     Inactive,
 		Status:                    Unlinked,
-		OAuthUID:                  "",
-		OAuthSecret:               "",
-		OAuthRedirectURI:          "",
-		SamlEntityID:              "http://www.okta.com/rijeonghyeok",
-		SamlIDPURL:                "https://foo.okta.com/app/fried/chicken/sso/saml",
-		SamlRelyingPartyTrustCert: "",
-		SamlX509Certs: []string{
-			"-----BEGIN CERTIFICATE----------END CERTIFICATE-----",
-		},
 	})
 
 	if err != nil {
@@ -412,13 +394,6 @@ func TestGetConnection(t *testing.T) {
 				State:                     Active,
 				Status:                    Linked,
 				Name:                      "Foo Corp",
-				OAuthRedirectURI:          "uri",
-				OAuthSecret:               "secret",
-				OAuthUID:                  "uid",
-				SamlEntityID:              "null",
-				SamlIDPURL:                "null",
-				SamlRelyingPartyTrustCert: "null",
-				SamlX509Certs:             []string{},
 			},
 		},
 	}
@@ -456,13 +431,6 @@ func getConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 		State:                     Active,
 		Status:                    Linked,
 		Name:                      "Foo Corp",
-		OAuthRedirectURI:          "uri",
-		OAuthSecret:               "secret",
-		OAuthUID:                  "uid",
-		SamlEntityID:              "null",
-		SamlIDPURL:                "null",
-		SamlRelyingPartyTrustCert: "null",
-		SamlX509Certs:             []string{},
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -500,13 +468,6 @@ func TestListConnections(t *testing.T) {
 						State:                     Active,
 						Status:                    Linked,
 						Name:                      "Foo Corp",
-						OAuthRedirectURI:          "uri",
-						OAuthSecret:               "secret",
-						OAuthUID:                  "uid",
-						SamlEntityID:              "null",
-						SamlIDPURL:                "null",
-						SamlRelyingPartyTrustCert: "null",
-						SamlX509Certs:             []string{},
 					},
 				},
 				ListMetadata: common.ListMetadata{
@@ -557,13 +518,6 @@ func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
 				State:                     Active,
 				Status:                    Linked,
 				Name:                      "Foo Corp",
-				OAuthRedirectURI:          "uri",
-				OAuthSecret:               "secret",
-				OAuthUID:                  "uid",
-				SamlEntityID:              "null",
-				SamlIDPURL:                "null",
-				SamlRelyingPartyTrustCert: "null",
-				SamlX509Certs:             []string{},
 			},
 		},
 		ListMetadata: common.ListMetadata{

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -98,11 +98,11 @@ func TestSsoGetConnection(t *testing.T) {
 	Configure("test", "client_123")
 
 	expectedResponse := Connection{
-		ID:                        "conn_id",
-		ConnectionType:            "GoogleOAuth",
-		State:                     Active,
-		Status:                    Linked,
-		Name:                      "Foo Corp",
+		ID:             "conn_id",
+		ConnectionType: "GoogleOAuth",
+		State:          Active,
+		Status:         Linked,
+		Name:           "Foo Corp",
 	}
 	connectionResponse, err := GetConnection(context.Background(), GetConnectionOpts{
 		Connection: "connection_id",
@@ -125,11 +125,11 @@ func TestSsoListConnections(t *testing.T) {
 	expectedResponse := ListConnectionsResponse{
 		Data: []Connection{
 			Connection{
-				ID:                        "conn_id",
-				ConnectionType:            "GoogleOAuth",
-				State:                     Active,
-				Status:                    Linked,
-				Name:                      "Foo Corp",
+				ID:             "conn_id",
+				ConnectionType: "GoogleOAuth",
+				State:          Active,
+				Status:         Linked,
+				Name:           "Foo Corp",
 			},
 		},
 		ListMetadata: common.ListMetadata{

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -103,13 +103,6 @@ func TestSsoGetConnection(t *testing.T) {
 		State:                     Active,
 		Status:                    Linked,
 		Name:                      "Foo Corp",
-		OAuthRedirectURI:          "uri",
-		OAuthSecret:               "secret",
-		OAuthUID:                  "uid",
-		SamlEntityID:              "null",
-		SamlIDPURL:                "null",
-		SamlRelyingPartyTrustCert: "null",
-		SamlX509Certs:             []string{},
 	}
 	connectionResponse, err := GetConnection(context.Background(), GetConnectionOpts{
 		Connection: "connection_id",
@@ -137,13 +130,6 @@ func TestSsoListConnections(t *testing.T) {
 				State:                     Active,
 				Status:                    Linked,
 				Name:                      "Foo Corp",
-				OAuthRedirectURI:          "uri",
-				OAuthSecret:               "secret",
-				OAuthUID:                  "uid",
-				SamlEntityID:              "null",
-				SamlIDPURL:                "null",
-				SamlRelyingPartyTrustCert: "null",
-				SamlX509Certs:             []string{},
 			},
 		},
 		ListMetadata: common.ListMetadata{


### PR DESCRIPTION
This PR removes the following deprecated fields from `Connection`s:

- `OAuthUID`
- `OAuthSecret`
- `OAuthRedirectURI`
- `SamlEntityID`
- `SamlIDPURL`
- `SamlRelyingPartyTrustCert`
- `SamlX509Certs`

This is a breaking change.

Resolves SDK-140.