### PR TITLE
Remove support for deprecated `ProjectID` parameter

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -46,14 +46,9 @@ type Client struct {
 	// REQUIRED.
 	APIKey string
 
-	// The WorkOS Project ID (eg. project_01JG3BCPTRTSTTWQR4VSHXGWCQ).
-	//
-	// Deprecated: Please use ClientID instead.
-	ProjectID string
-
 	// The WorkOS Client ID (eg. client_01JG3BCPTRTSTTWQR4VSHXGWCQ).
 	//
-	// Either ProjectID or ClientID is REQUIRED while we deprecate ProjectID.
+	// REQUIRED.
 	ClientID string
 
 	// The endpoint to WorkOS API.
@@ -121,11 +116,7 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 	redirectURI := opts.RedirectURI
 
 	query := make(url.Values, 5)
-	if c.ClientID != "" {
-		query.Set("client_id", c.ClientID)
-	} else if c.ProjectID != "" {
-		query.Set("project_id", c.ProjectID)
-	}
+	query.Set("client_id", c.ClientID)
 	query.Set("redirect_uri", redirectURI)
 	query.Set("response_type", "code")
 
@@ -195,11 +186,7 @@ func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profil
 	c.once.Do(c.init)
 
 	form := make(url.Values, 5)
-	if c.ClientID != "" {
-		form.Set("client_id", c.ClientID)
-	} else if c.ProjectID != "" {
-		form.Set("project_id", c.ProjectID)
-	}
+	form.Set("client_id", c.ClientID)
 	form.Set("client_secret", c.APIKey)
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", opts.Code)

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -16,7 +16,6 @@ var (
 // Configure configures the default client that is used by GetAuthorizationURL,
 // GetProfile and Login.
 // It must be called before using those functions.
-// Deprecated: Please pass clientID as an argument, not projectID.
 func Configure(apiKey, clientID string) {
 	DefaultClient.APIKey = apiKey
 	DefaultClient.ClientID = clientID


### PR DESCRIPTION
This PR removes support for the deprecated `ProjectID` parameter.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-163.