### PR TITLE
Rename `GetProfile` to `GetProfileAndToken`

### DIFF
--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -95,11 +95,11 @@ func TestClientAuthorizeURLWithNoConnectionDomainAndProvider(t *testing.T) {
 	require.Nil(t, u)
 }
 
-func TestClientGetProfile(t *testing.T) {
+func TestClientGetProfileAndToken(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetProfileOptions
+		options  GetProfileAndTokenOptions
 		expected Profile
 		err      bool
 	}{
@@ -114,7 +114,7 @@ func TestClientGetProfile(t *testing.T) {
 				APIKey:   "test",
 				ClientID: "client_123",
 			},
-			options: GetProfileOptions{
+			options: GetProfileAndTokenOptions{
 				Code: "authorization_code",
 			},
 			expected: Profile{
@@ -144,13 +144,13 @@ func TestClientGetProfile(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			profile, err := client.GetProfile(context.Background(), test.options)
+			profileAndToken, err := client.GetProfileAndToken(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.expected, profile)
+			require.Equal(t, test.expected, profileAndToken.Profile)
 		})
 	}
 }

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -8,13 +8,13 @@ import (
 )
 
 var (
-	// DefaultClient is the client used by GetAuthorizationURL, GetProfile and
+	// DefaultClient is the client used by GetAuthorizationURL, GetProfileAndToken and
 	// Login functions.
 	DefaultClient = &Client{}
 )
 
 // Configure configures the default client that is used by GetAuthorizationURL,
-// GetProfile and Login.
+// GetProfileAndToken and Login.
 // It must be called before using those functions.
 func Configure(apiKey, clientID string) {
 	DefaultClient.APIKey = apiKey
@@ -27,10 +27,10 @@ func GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL, error) {
 	return DefaultClient.GetAuthorizationURL(opts)
 }
 
-// GetProfile returns a profile describing the user that authenticated with
+// GetProfileAndToken returns a profile describing the user that authenticated with
 // WorkOS SSO.
-func GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
-	return DefaultClient.GetProfile(ctx, opts)
+func GetProfileAndToken(ctx context.Context, opts GetProfileAndTokenOptions) (ProfileAndToken, error) {
+	return DefaultClient.GetProfileAndToken(ctx, opts)
 }
 
 // Login return a http.Handler that redirects client to the appropriate

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -57,14 +57,14 @@ func TestLogin(t *testing.T) {
 	})
 
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		p, err := GetProfile(context.Background(), GetProfileOptions{
+		p, err := GetProfileAndToken(context.Background(), GetProfileAndTokenOptions{
 			Code: "authorization_code",
 		})
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		profile = p
+		profile = p.Profile
 
 		w.WriteHeader(http.StatusOK)
 		wg.Done()


### PR DESCRIPTION
This PR renames the `GetProfile` method to `GetProfileAndToken`.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-156.