### PR TITLE
Export Public Error Functions

### DIFF
--- a/pkg/workos_errors/errors.go
+++ b/pkg/workos_errors/errors.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func ErrIsBadRequest(err error) bool {
+func IsBadRequest(err error) bool {
 	var httpError workos.HTTPError
 	return errors.As(err, &httpError) && httpError.Code == http.StatusBadRequest
 }

--- a/pkg/workos_errors/errors.go
+++ b/pkg/workos_errors/errors.go
@@ -1,0 +1,12 @@
+package workos_errors
+
+import (
+	"errors"
+	"github.com/workos-inc/workos-go/internal/workos"
+	"net/http"
+)
+
+func ErrIsBadRequest(err error) bool {
+	var httpError workos.HTTPError
+	return errors.As(err, &httpError) && httpError.Code == http.StatusBadRequest
+}

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -45,7 +45,7 @@ func TestIsBadRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := workos_errors.IsBadRequest(tt.args.err); got != tt.want {
-				t.Errorf("ErrIsBadRequest() = %v, want %v", got, tt.want)
+				t.Errorf("IsBadRequest() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestErrIsBadRequest(t *testing.T) {
+func TestIsBadRequest(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -44,7 +44,7 @@ func TestErrIsBadRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := workos_errors.ErrIsBadRequest(tt.args.err); got != tt.want {
+			if got := workos_errors.IsBadRequest(tt.args.err); got != tt.want {
 				t.Errorf("ErrIsBadRequest() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -1,0 +1,52 @@
+package workos_errors_test
+
+import (
+	"fmt"
+	"github.com/workos-inc/workos-go/internal/workos"
+	"github.com/workos-inc/workos-go/pkg/workos_errors"
+	"net/http"
+	"testing"
+)
+
+func TestErrIsBadRequest(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "bad request",
+			args: args{err: workos.HTTPError{
+				Code: http.StatusBadRequest,
+			}},
+			want: true,
+		},
+		{
+			name: "internal server error",
+			args: args{err: workos.HTTPError{
+				Code: http.StatusInternalServerError,
+			}},
+			want: false,
+		},
+		{
+			name: "unknown error",
+			args: args{err: fmt.Errorf("unknown error")},
+			want: false,
+		},
+		{
+			name: "nil",
+			args: args{err: nil},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workos_errors.ErrIsBadRequest(tt.args.err); got != tt.want {
+				t.Errorf("ErrIsBadRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[issue](https://github.com/workos-inc/workos-go/issues/83)

pr to export a public error function that will allow me to tell whether a request failed to it being a bad request or not

this will save me writing code like:
```go
if strings.Contains(err.Error(), "400 Bad Request") {
   return nil, internal.ErrInvalidCode
}