### PR TITLE
add organization id to directory

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -403,6 +403,9 @@ type Directory struct {
 
 	// The user's directory provider's Identifier
 	IdpID string `json:"idp_id"`
+
+	// Identifier for the Directory's Organization.
+	OrganizationID string `json:"organization_id"`
 }
 
 // ListDirectoriesOpts contains the options to request a Project's Directories.


### PR DESCRIPTION
hey guys 👋 

pr to add `organization_id` field to `directory` as shown [here](https://workos.com/docs/reference/directory-sync/directory)

we'll be able to link directories to an organization using this

![](https://media.giphy.com/media/icUEIrjnUuFCWDxFpU/giphy.gif)