### PR TITLE
Add support for `AllowProfilesOutsideOrganization` for organizations

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -66,6 +66,10 @@ type Organization struct {
 	// The Organization's name.
 	Name string `json:"name"`
 
+	// Whether Connections within the Organization allow profiles that are
+	// outside of the Organization's configured User Email Domains.
+	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
+
 	// The Organization's Domains.
 	Domains []OrganizationDomain `json:"domains"`
 
@@ -109,11 +113,15 @@ type ListOrganizationsResponse struct {
 
 // CreateOrganizationOpts contains the options to create an Organization.
 type CreateOrganizationOpts struct {
-	// Domains of the Organization.
-	Domains []string `json:"domains"`
-
 	// Name of the Organization.
 	Name string `json:"name"`
+
+	// Whether Connections within the Organization allow profiles that are
+	// outside of the Organization's configured User Email Domains.
+	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
+
+	// Domains of the Organization.
+	Domains []string `json:"domains"`
 }
 
 // UpdateOrganizationOpts contains the options to update an Organization.
@@ -121,11 +129,15 @@ type UpdateOrganizationOpts struct {
 	// Organization unique identifier.
 	Organization string
 
-	// Domains of the Organization.
-	Domains []string
-
 	// Name of the Organization.
 	Name string
+
+	// Whether Connections within the Organization allow profiles that are
+	// outside of the Organization's configured User Email Domains.
+	AllowProfilesOutsideOrganization bool
+
+	// Domains of the Organization.
+	Domains []string
 }
 
 // GetOrganization gets an Organization.
@@ -260,14 +272,18 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 
 	// UpdateOrganizationChangeOpts contains the options to update an Organization minus the org ID
 	type UpdateOrganizationChangeOpts struct {
-		// Domains of the Organization.
-		Domains []string `json:"domains"`
-
 		// Name of the Organization.
 		Name string `json:"name"`
+
+		// Whether Connections within the Organization allow profiles that are
+		// outside of the Organization's configured User Email Domains.
+		AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
+
+		// Domains of the Organization.
+		Domains []string `json:"domains"`
 	}
 
-	update_opts := UpdateOrganizationChangeOpts{opts.Domains, opts.Name}
+	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.Domains}
 
 	data, err := c.JSONEncode(update_opts)
 	if err != nil {

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -34,8 +34,9 @@ func TestGetOrganization(t *testing.T) {
 				Organization: "organization_id",
 			},
 			expected: Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
+				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
 						ID:     "organization_domain_id",
@@ -74,8 +75,9 @@ func getOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Organization{
-		ID:   "organization_id",
-		Name: "Foo Corp",
+		ID:                               "organization_id",
+		Name:                             "Foo Corp",
+		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
 			OrganizationDomain{
 				ID:     "organization_domain_id",
@@ -117,8 +119,9 @@ func TestListOrganizations(t *testing.T) {
 			expected: ListOrganizationsResponse{
 				Data: []Organization{
 					Organization{
-						ID:   "organization_id",
-						Name: "Foo Corp",
+						ID:                               "organization_id",
+						Name:                             "Foo Corp",
+						AllowProfilesOutsideOrganization: false,
 						Domains: []OrganizationDomain{
 							OrganizationDomain{
 								ID:     "organization_domain_id",
@@ -173,8 +176,9 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListOrganizationsResponse: ListOrganizationsResponse{
 			Data: []Organization{
 				Organization{
-					ID:   "organization_id",
-					Name: "Foo Corp",
+					ID:                               "organization_id",
+					Name:                             "Foo Corp",
+					AllowProfilesOutsideOrganization: false,
 					Domains: []OrganizationDomain{
 						OrganizationDomain{
 							ID:     "organization_domain_id",
@@ -221,8 +225,9 @@ func TestCreateOrganization(t *testing.T) {
 				Domains: []string{"foo-corp.com"},
 			},
 			expected: Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
+				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
 						ID:     "organization_domain_id",
@@ -287,8 +292,9 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
+			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
 					ID:     "organization_domain_id",
@@ -330,8 +336,9 @@ func TestUpdateOrganization(t *testing.T) {
 				Domains:      []string{"foo-corp.com", "foo-corp.io"},
 			},
 			expected: Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
+				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
 						ID:     "organization_domain_id",
@@ -401,8 +408,9 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
+			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
 					ID:     "organization_domain_id",

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -34,8 +34,8 @@ func TestGetOrganization(t *testing.T) {
 				Organization: "organization_id",
 			},
 			expected: Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
+				ID:   "organization_id",
+				Name: "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -75,8 +75,8 @@ func getOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Organization{
-		ID:                               "organization_id",
-		Name:                             "Foo Corp",
+		ID:   "organization_id",
+		Name: "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
 			OrganizationDomain{
@@ -119,8 +119,8 @@ func TestListOrganizations(t *testing.T) {
 			expected: ListOrganizationsResponse{
 				Data: []Organization{
 					Organization{
-						ID:                               "organization_id",
-						Name:                             "Foo Corp",
+						ID:   "organization_id",
+						Name: "Foo Corp",
 						AllowProfilesOutsideOrganization: false,
 						Domains: []OrganizationDomain{
 							OrganizationDomain{
@@ -176,8 +176,8 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListOrganizationsResponse: ListOrganizationsResponse{
 			Data: []Organization{
 				Organization{
-					ID:                               "organization_id",
-					Name:                             "Foo Corp",
+					ID:   "organization_id",
+					Name: "Foo Corp",
 					AllowProfilesOutsideOrganization: false,
 					Domains: []OrganizationDomain{
 						OrganizationDomain{
@@ -225,8 +225,8 @@ func TestCreateOrganization(t *testing.T) {
 				Domains: []string{"foo-corp.com"},
 			},
 			expected: Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
+				ID:   "organization_id",
+				Name: "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -292,8 +292,8 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
+			ID:   "organization_id",
+			Name: "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
@@ -336,8 +336,8 @@ func TestUpdateOrganization(t *testing.T) {
 				Domains:      []string{"foo-corp.com", "foo-corp.io"},
 			},
 			expected: Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
+				ID:   "organization_id",
+				Name: "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -408,8 +408,8 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
+			ID:   "organization_id",
+			Name: "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -21,8 +21,9 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Organization{
-		ID:   "organization_id",
-		Name: "Foo Corp",
+		ID:                               "organization_id",
+		Name:                             "Foo Corp",
+		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
 			OrganizationDomain{
 				ID:     "organization_domain_id",
@@ -51,8 +52,9 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 	expectedResponse := ListOrganizationsResponse{
 		Data: []Organization{
 			Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
+				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
 						ID:     "organization_domain_id",
@@ -87,8 +89,9 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
+			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
 					ID:     "organization_domain_id",
@@ -118,8 +121,9 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
+			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
 					ID:     "organization_domain_id",

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -21,8 +21,8 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Organization{
-		ID:                               "organization_id",
-		Name:                             "Foo Corp",
+		ID:   "organization_id",
+		Name: "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
 			OrganizationDomain{
@@ -52,8 +52,8 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 	expectedResponse := ListOrganizationsResponse{
 		Data: []Organization{
 			Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
+				ID:   "organization_id",
+				Name: "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -89,8 +89,8 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
+			ID:   "organization_id",
+			Name: "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
@@ -121,8 +121,8 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
+			ID:   "organization_id",
+			Name: "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{


### PR DESCRIPTION
This PR adds support for the `AllowProfilesOutsideOrganization` field for organization objects and operations.

Resolves SDK-259.