### PR TITLE
update version number for webhook validation

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v1.4.0"
+	Version = "v1.5.0"
 )

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v1.5.0"
+	Version = "v1.5.1"
 )

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v1.5.1"
+	Version = "v1.5.0"
 )


### PR DESCRIPTION
Updating version number from 1.4.0 to 1.5.0 to reflect the newly merged webhook validation methods. 