### PR TITLE
export validate payload

### DIFF
--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -41,7 +41,7 @@ func parseSignatureHeader(header string) (*signedHeader, error) {
 	signedHeader.timestamp = rawTimestamp
 
 	// Create the signature and check that it exists
-	signedHeader.signature = (signatureParts[1][4:len(signatureParts[1])])
+	signedHeader.signature = signatureParts[1][4:len(signatureParts[1])]
 	if len(signedHeader.signature) == 0 {
 		return signedHeader, ErrNoValidSignature
 	}
@@ -70,7 +70,7 @@ func checkTimestamp(timestamp string, defaultTolerance time.Duration) error {
 
 func checkSignature(bodyString string, rawTimestamp string, signature string, secret string) error {
 	// Create the digest
-	unhashedDigest := (rawTimestamp + "." + bodyString)
+	unhashedDigest := rawTimestamp + "." + bodyString
 	hash := hmac.New(sha256.New, []byte(secret))
 
 	// Write Data to it
@@ -87,7 +87,7 @@ func checkSignature(bodyString string, rawTimestamp string, signature string, se
 	}
 }
 
-func validatePayload(workosHeader string, bodyString string, secret string, defaultTolerance time.Duration) (string, error) {
+func ValidatePayload(workosHeader string, bodyString string, secret string, defaultTolerance time.Duration) (string, error) {
 	header, err := parseSignatureHeader(workosHeader)
 	if err != nil {
 		return "", err

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -1,27 +1,28 @@
-package webhooks
+package webhooks_test
 
 import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/workos-inc/workos-go/pkg/webhooks"
 	"strconv"
 	"testing"
 	"time"
 )
 
 func TestWebhooks(t *testing.T) {
-	const defaultTolerance time.Duration = 180 * time.Second
-	time := time.Now().Round(0).Unix()
+	const defaultTolerance = 180 * time.Second
+	now := time.Now().Round(0).Unix()
 	payload := "{'id':'wh_01FHTNQPSYGA4Z25QSZYPY4659','data':{'id':'conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6','name':'Foo Corp's Connection','state':'active','object':'connection','domains':[{'id':'conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB','domain':'foo-corp.com','object':'connection_domain'}],'connection_type':'OktaSAML','organization_id':'org_01EHWNCE74X7JSDV0X3SZ3KJNY'},'event':'connection.activated'}"
 	secret := "secret"
-	stringTime := strconv.FormatInt(time*1000, 10)
+	stringTime := strconv.FormatInt(now*1000, 10)
 	signedPayload := stringTime + "." + payload
 	convertedSecret := hmac.New(sha256.New, []byte(secret))
 	convertedSecret.Write([]byte(signedPayload))
 	expectedSignature := hex.EncodeToString(convertedSecret.Sum(nil))
 	header := "t=" + stringTime + ", v1=" + expectedSignature
 
-	actual, err := validatePayload(header, payload, secret, defaultTolerance)
+	actual, err := webhooks.ValidatePayload(header, payload, secret, defaultTolerance)
 	if err != nil {
 		t.Errorf("expected no error, but got %v", err)
 	}


### PR DESCRIPTION
[Issue](https://github.com/workos-inc/workos-go/issues/128#issue-1056102581)

👋 pr to export validate payload in `webhooks`

also added a method to inject the current time dependency (for testing).