### PR TITLE
Finalize `webhooks` package interface for next release

### DIFF
--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -33,16 +33,14 @@ func NewClient(secret string) *Client {
 
 // Sets the function used to determine the current time. Usually you'll only
 // need to call this for testing purposes.
-func (c Client) SetNow(now func() time.Time) Client {
+func (c *Client) SetNow(now func() time.Time) {
 	c.now = now
-	return c
 }
 
 // Sets the maximum time tolerance between now and when the webhook timestmap
 // was issued.
-func (c Client) SetTolerance(tolerance time.Duration) Client {
+func (c *Client) SetTolerance(tolerance time.Duration) {
 	c.tolerance = tolerance
-	return c
 }
 
 type signedHeader struct {
@@ -75,7 +73,7 @@ func parseSignatureHeader(header string) (*signedHeader, error) {
 	return signedHeader, nil
 }
 
-func (c Client) checkTimestamp(timestamp string) error {
+func (c *Client) checkTimestamp(timestamp string) error {
 	intTimestamp, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return ErrInvalidHeader
@@ -93,7 +91,7 @@ func (c Client) checkTimestamp(timestamp string) error {
 	}
 }
 
-func (c Client) checkSignature(bodyString string, rawTimestamp string, signature string) error {
+func (c *Client) checkSignature(bodyString string, rawTimestamp string, signature string) error {
 	unhashedDigest := rawTimestamp + "." + bodyString
 	hash := hmac.New(sha256.New, []byte(c.secret))
 
@@ -108,7 +106,7 @@ func (c Client) checkSignature(bodyString string, rawTimestamp string, signature
 	}
 }
 
-func (c Client) ValidatePayload(workosHeader string, bodyString string) (string, error) {
+func (c *Client) ValidatePayload(workosHeader string, bodyString string) (string, error) {
 	header, err := parseSignatureHeader(workosHeader)
 	if err != nil {
 		return "", err

--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -73,13 +73,12 @@ func checkTimestamp(timestamp string, defaultTolerance time.Duration, now time.T
 	if err != nil {
 		return ErrInvalidHeader
 	}
-	// Transform Timestamp into unix time in seconds
+
 	formattedTime := time.Unix(intTimestamp/1000, 0)
-	// Get current time
 	currentTime := now.Round(0)
-	// Calculate the difference between current time and the formatted time
+
 	diff := currentTime.Sub(formattedTime)
-	// Compare the difference in the time to the default tolerance
+
 	if diff < defaultTolerance {
 		return nil
 	} else {
@@ -88,17 +87,13 @@ func checkTimestamp(timestamp string, defaultTolerance time.Duration, now time.T
 }
 
 func checkSignature(bodyString string, rawTimestamp string, signature string, secret string) error {
-	// Create the digest
 	unhashedDigest := rawTimestamp + "." + bodyString
 	hash := hmac.New(sha256.New, []byte(secret))
 
-	// Write Data to it
 	hash.Write([]byte(unhashedDigest))
 
-	// Get result and encode as hexadecimal string
 	digest := hex.EncodeToString(hash.Sum(nil))
 
-	// Return an error if the signature and digest aren't equal
 	if signature == digest {
 		return nil
 	} else {

--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -27,14 +27,21 @@ type Client struct {
 }
 
 // Constructs a new Client.
-func NewClient(secret string, tolerance time.Duration) *Client {
-	return &Client{now: time.Now, tolerance: tolerance, secret: secret}
+func NewClient(secret string) *Client {
+	return &Client{now: time.Now, tolerance: 180 * time.Second, secret: secret}
 }
 
 // Sets the function used to determine the current time. Usually you'll only
 // need to call this for testing purposes.
 func (c Client) SetNow(now func() time.Time) Client {
 	c.now = now
+	return c
+}
+
+// Sets the maximum time tolerance between now and when the webhook timestmap
+// was issued.
+func (c Client) SetTolerance(tolerance time.Duration) Client {
+	c.tolerance = tolerance
 	return c
 }
 

--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -19,16 +19,20 @@ var (
 	ErrOutsideTolerance = errors.New("webhook has a timestamp that is out of tolerance")
 )
 
+// The Client used to interact with Webhooks.
 type Client struct {
 	now              func() time.Time
 	defaultTolerance time.Duration
 	secret           string
 }
 
+// Constructs a new Client.
 func NewClient(secret string, defaultTolerance time.Duration) *Client {
 	return &Client{now: time.Now, defaultTolerance: defaultTolerance, secret: secret}
 }
 
+// Sets the function used to determine the current time. Usually you'll only
+// need to call this for testing purposes.
 func (c Client) SetNow(now func() time.Time) Client {
 	c.now = now
 	return c

--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -106,10 +106,6 @@ func checkSignature(bodyString string, rawTimestamp string, signature string, se
 	}
 }
 
-func ValidatePayload(workosHeader string, bodyString string, secret string, defaultTolerance time.Duration) (string, error) {
-	return NewClient(secret, defaultTolerance).ValidatePayload(workosHeader, bodyString)
-}
-
 func (c Client) ValidatePayload(workosHeader string, bodyString string) (string, error) {
 	header, err := parseSignatureHeader(workosHeader)
 	if err != nil {

--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -21,14 +21,14 @@ var (
 
 // The Client used to interact with Webhooks.
 type Client struct {
-	now              func() time.Time
-	defaultTolerance time.Duration
-	secret           string
+	now       func() time.Time
+	tolerance time.Duration
+	secret    string
 }
 
 // Constructs a new Client.
-func NewClient(secret string, defaultTolerance time.Duration) *Client {
-	return &Client{now: time.Now, defaultTolerance: defaultTolerance, secret: secret}
+func NewClient(secret string, tolerance time.Duration) *Client {
+	return &Client{now: time.Now, tolerance: tolerance, secret: secret}
 }
 
 // Sets the function used to determine the current time. Usually you'll only
@@ -79,7 +79,7 @@ func (c Client) checkTimestamp(timestamp string) error {
 
 	diff := currentTime.Sub(formattedTime)
 
-	if diff < c.defaultTolerance {
+	if diff < c.tolerance {
 		return nil
 	} else {
 		return ErrInvalidTimestamp

--- a/pkg/webhooks/client.go
+++ b/pkg/webhooks/client.go
@@ -37,7 +37,7 @@ func (c *Client) SetNow(now func() time.Time) {
 	c.now = now
 }
 
-// Sets the maximum time tolerance between now and when the webhook timestmap
+// Sets the maximum time tolerance between now and when the webhook timestamp
 // was issued.
 func (c *Client) SetTolerance(tolerance time.Duration) {
 	c.tolerance = tolerance

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -10,14 +10,14 @@ import (
 	"time"
 )
 
-func TestWebhooks(t *testing.T) {
+func TestWebhookWithValidHeader(t *testing.T) {
 	defaultTolerance := 180 * time.Second
 	secret := "secret"
 
 	client := webhooks.NewClient(secret, defaultTolerance)
 
 	now := time.Now()
-	body := "{'id':'wh_01FHTNQPSYGA4Z25QSZYPY4659','data':{'id':'conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6','name':'Foo Corp's Connection','state':'active','object':'connection','domains':[{'id':'conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB','domain':'foo-corp.com','object':'connection_domain'}],'connection_type':'OktaSAML','organization_id':'org_01EHWNCE74X7JSDV0X3SZ3KJNY'},'event':'connection.activated'}"
+	body := "{'data': 'foobar'}"
 	header := mockWebhookHeader(now, secret, body)
 
 	actual, err := client.ValidatePayload(header, body)

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -16,21 +16,26 @@ func TestWebhooks(t *testing.T) {
 
 	client := webhooks.NewClient(secret, defaultTolerance)
 
-	now := time.Now().Round(0).Unix()
-	payload := "{'id':'wh_01FHTNQPSYGA4Z25QSZYPY4659','data':{'id':'conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6','name':'Foo Corp's Connection','state':'active','object':'connection','domains':[{'id':'conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB','domain':'foo-corp.com','object':'connection_domain'}],'connection_type':'OktaSAML','organization_id':'org_01EHWNCE74X7JSDV0X3SZ3KJNY'},'event':'connection.activated'}"
-	stringTime := strconv.FormatInt(now*1000, 10)
-	signedPayload := stringTime + "." + payload
-	convertedSecret := hmac.New(sha256.New, []byte(secret))
-	convertedSecret.Write([]byte(signedPayload))
-	expectedSignature := hex.EncodeToString(convertedSecret.Sum(nil))
-	header := "t=" + stringTime + ", v1=" + expectedSignature
+	now := time.Now()
+	body := "{'id':'wh_01FHTNQPSYGA4Z25QSZYPY4659','data':{'id':'conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6','name':'Foo Corp's Connection','state':'active','object':'connection','domains':[{'id':'conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB','domain':'foo-corp.com','object':'connection_domain'}],'connection_type':'OktaSAML','organization_id':'org_01EHWNCE74X7JSDV0X3SZ3KJNY'},'event':'connection.activated'}"
+	header := mockWebhookHeader(now, secret, body)
 
-	actual, err := client.ValidatePayload(header, payload)
+	actual, err := client.ValidatePayload(header, body)
 	if err != nil {
 		t.Errorf("expected no error, but got %v", err)
 	}
 
-	if actual != payload {
-		t.Errorf("expected output to be %s, but got %s", payload, actual)
+	if actual != body {
+		t.Errorf("expected output to be %s, but got %s", body, actual)
 	}
+}
+
+func mockWebhookHeader(now time.Time, secret string, body string) string {
+	stringTime := strconv.FormatInt(now.Round(0).Unix()*1000, 10)
+	signedBody := stringTime + "." + body
+	convertedSecret := hmac.New(sha256.New, []byte(secret))
+	convertedSecret.Write([]byte(signedBody))
+	expectedSignature := hex.EncodeToString(convertedSecret.Sum(nil))
+
+	return "t=" + stringTime + ", v1=" + expectedSignature
 }

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -34,9 +34,8 @@ func TestWebhookWithInvalidSecret(t *testing.T) {
 
 	client := webhooks.NewClient(secret)
 
-	now := time.Now()
 	body := "{'data': 'foobar'}"
-	header := mockWebhookHeader(now, "other_secret", body)
+	header := mockWebhookHeader(time.Now(), "other_secret", body)
 
 	_, err := client.ValidatePayload(header, body)
 	if err != webhooks.ErrNoValidSignature {
@@ -49,9 +48,8 @@ func TestWebhookWithEmptySecret(t *testing.T) {
 
 	client := webhooks.NewClient(secret)
 
-	now := time.Now()
 	body := "{'data': 'foobar'}"
-	header := mockWebhookHeader(now, "", body)
+	header := mockWebhookHeader(time.Now(), "", body)
 
 	_, err := client.ValidatePayload(header, body)
 	if err != webhooks.ErrNoValidSignature {
@@ -115,9 +113,8 @@ func TestWebhookWithInvalidSignature(t *testing.T) {
 
 	client := webhooks.NewClient(secret)
 
-	now := time.Now()
 	body := "{'data': 'foobar'}"
-	header := mockWebhookHeader(now, secret, body)
+	header := mockWebhookHeader(time.Now(), secret, body)
 
 	_, err := client.ValidatePayload(header, "{'data': 'bazbiz'}")
 	if err != webhooks.ErrNoValidSignature {

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -11,10 +11,9 @@ import (
 )
 
 func TestWebhookWithValidHeader(t *testing.T) {
-	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, tolerance)
+	client := webhooks.NewClient(secret)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"
@@ -31,10 +30,9 @@ func TestWebhookWithValidHeader(t *testing.T) {
 }
 
 func TestWebhookWithInvalidSecret(t *testing.T) {
-	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, tolerance)
+	client := webhooks.NewClient(secret)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"
@@ -47,10 +45,9 @@ func TestWebhookWithInvalidSecret(t *testing.T) {
 }
 
 func TestWebhookWithEmptySecret(t *testing.T) {
-	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, tolerance)
+	client := webhooks.NewClient(secret)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"
@@ -63,10 +60,9 @@ func TestWebhookWithEmptySecret(t *testing.T) {
 }
 
 func TestWebhookWithInvalidHeader(t *testing.T) {
-	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, tolerance)
+	client := webhooks.NewClient(secret)
 	body := "{'data': 'foobar'}"
 
 	_, err := client.ValidatePayload("some_junk", body)
@@ -80,11 +76,11 @@ func TestWebhookWithTimestampOlderThanTolerance(t *testing.T) {
 	secret := "secret"
 	now := time.Unix(0, 0)
 
-	client := webhooks.NewClient(secret, tolerance)
-	client.SetNow(func() time.Time { return now })
+	client := webhooks.NewClient(secret).
+		SetNow(func() time.Time { return now.Add(tolerance + time.Second) })
 
 	body := "{'data': 'foobar'}"
-	header := mockWebhookHeader(now.Add(tolerance+time.Second), "", body)
+	header := mockWebhookHeader(now, secret, body)
 
 	_, err := client.ValidatePayload(header, body)
 	if err != webhooks.ErrInvalidTimestamp {
@@ -92,11 +88,32 @@ func TestWebhookWithTimestampOlderThanTolerance(t *testing.T) {
 	}
 }
 
+func TestWebhookWithCustomTolerance(t *testing.T) {
+	tolerance := 240 * time.Second
+	secret := "secret"
+	now := time.Unix(0, 0)
+
+	client := webhooks.NewClient(secret).
+		SetNow(func() time.Time { return now.Add(200 * time.Second) }).
+		SetTolerance(tolerance)
+
+	body := "{'data': 'foobar'}"
+	header := mockWebhookHeader(now, secret, body)
+
+	actual, err := client.ValidatePayload(header, body)
+	if err != nil {
+		t.Errorf("expected no error, but got '%s'", err)
+	}
+
+	if actual != body {
+		t.Errorf("expected output to be '%s', but got '%s'", body, actual)
+	}
+}
+
 func TestWebhookWithInvalidSignature(t *testing.T) {
-	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, tolerance)
+	client := webhooks.NewClient(secret)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -11,10 +11,13 @@ import (
 )
 
 func TestWebhooks(t *testing.T) {
-	const defaultTolerance = 180 * time.Second
+	defaultTolerance := 180 * time.Second
+	secret := "secret"
+
+	client := webhooks.NewClient(secret, defaultTolerance)
+
 	now := time.Now().Round(0).Unix()
 	payload := "{'id':'wh_01FHTNQPSYGA4Z25QSZYPY4659','data':{'id':'conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6','name':'Foo Corp's Connection','state':'active','object':'connection','domains':[{'id':'conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB','domain':'foo-corp.com','object':'connection_domain'}],'connection_type':'OktaSAML','organization_id':'org_01EHWNCE74X7JSDV0X3SZ3KJNY'},'event':'connection.activated'}"
-	secret := "secret"
 	stringTime := strconv.FormatInt(now*1000, 10)
 	signedPayload := stringTime + "." + payload
 	convertedSecret := hmac.New(sha256.New, []byte(secret))
@@ -22,7 +25,7 @@ func TestWebhooks(t *testing.T) {
 	expectedSignature := hex.EncodeToString(convertedSecret.Sum(nil))
 	header := "t=" + stringTime + ", v1=" + expectedSignature
 
-	actual, err := webhooks.ValidatePayload(header, payload, secret, defaultTolerance)
+	actual, err := client.ValidatePayload(header, payload)
 	if err != nil {
 		t.Errorf("expected no error, but got %v", err)
 	}
@@ -30,5 +33,4 @@ func TestWebhooks(t *testing.T) {
 	if actual != payload {
 		t.Errorf("expected output to be %s, but got %s", payload, actual)
 	}
-
 }

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestWebhookWithValidHeader(t *testing.T) {
-	defaultTolerance := 180 * time.Second
+	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, defaultTolerance)
+	client := webhooks.NewClient(secret, tolerance)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"
@@ -31,10 +31,10 @@ func TestWebhookWithValidHeader(t *testing.T) {
 }
 
 func TestWebhookWithInvalidSecret(t *testing.T) {
-	defaultTolerance := 180 * time.Second
+	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, defaultTolerance)
+	client := webhooks.NewClient(secret, tolerance)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"
@@ -47,10 +47,10 @@ func TestWebhookWithInvalidSecret(t *testing.T) {
 }
 
 func TestWebhookWithEmptySecret(t *testing.T) {
-	defaultTolerance := 180 * time.Second
+	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, defaultTolerance)
+	client := webhooks.NewClient(secret, tolerance)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"
@@ -63,10 +63,10 @@ func TestWebhookWithEmptySecret(t *testing.T) {
 }
 
 func TestWebhookWithInvalidHeader(t *testing.T) {
-	defaultTolerance := 180 * time.Second
+	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, defaultTolerance)
+	client := webhooks.NewClient(secret, tolerance)
 	body := "{'data': 'foobar'}"
 
 	_, err := client.ValidatePayload("some_junk", body)
@@ -76,15 +76,15 @@ func TestWebhookWithInvalidHeader(t *testing.T) {
 }
 
 func TestWebhookWithTimestampOlderThanTolerance(t *testing.T) {
-	defaultTolerance := 180 * time.Second
+	tolerance := 180 * time.Second
 	secret := "secret"
 	now := time.Unix(0, 0)
 
-	client := webhooks.NewClient(secret, defaultTolerance)
+	client := webhooks.NewClient(secret, tolerance)
 	client.SetNow(func() time.Time { return now })
 
 	body := "{'data': 'foobar'}"
-	header := mockWebhookHeader(now.Add(defaultTolerance+time.Second), "", body)
+	header := mockWebhookHeader(now.Add(tolerance+time.Second), "", body)
 
 	_, err := client.ValidatePayload(header, body)
 	if err != webhooks.ErrInvalidTimestamp {
@@ -93,10 +93,10 @@ func TestWebhookWithTimestampOlderThanTolerance(t *testing.T) {
 }
 
 func TestWebhookWithInvalidSignature(t *testing.T) {
-	defaultTolerance := 180 * time.Second
+	tolerance := 180 * time.Second
 	secret := "secret"
 
-	client := webhooks.NewClient(secret, defaultTolerance)
+	client := webhooks.NewClient(secret, tolerance)
 
 	now := time.Now()
 	body := "{'data': 'foobar'}"

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -74,8 +74,8 @@ func TestWebhookWithTimestampOlderThanTolerance(t *testing.T) {
 	secret := "secret"
 	now := time.Unix(0, 0)
 
-	client := webhooks.NewClient(secret).
-		SetNow(func() time.Time { return now.Add(tolerance + time.Second) })
+	client := webhooks.NewClient(secret)
+	client.SetNow(func() time.Time { return now.Add(tolerance + time.Second) })
 
 	body := "{'data': 'foobar'}"
 	header := mockWebhookHeader(now, secret, body)
@@ -91,9 +91,9 @@ func TestWebhookWithCustomTolerance(t *testing.T) {
 	secret := "secret"
 	now := time.Unix(0, 0)
 
-	client := webhooks.NewClient(secret).
-		SetNow(func() time.Time { return now.Add(200 * time.Second) }).
-		SetTolerance(tolerance)
+	client := webhooks.NewClient(secret)
+	client.SetNow(func() time.Time { return now.Add(200 * time.Second) })
+	client.SetTolerance(tolerance)
 
 	body := "{'data': 'foobar'}"
 	header := mockWebhookHeader(now, secret, body)

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -26,7 +26,85 @@ func TestWebhookWithValidHeader(t *testing.T) {
 	}
 
 	if actual != body {
-		t.Errorf("expected output to be %s, but got %s", body, actual)
+		t.Errorf("expected output to be '%s', but got '%s'", body, actual)
+	}
+}
+
+func TestWebhookWithInvalidSecret(t *testing.T) {
+	defaultTolerance := 180 * time.Second
+	secret := "secret"
+
+	client := webhooks.NewClient(secret, defaultTolerance)
+
+	now := time.Now()
+	body := "{'data': 'foobar'}"
+	header := mockWebhookHeader(now, "other_secret", body)
+
+	_, err := client.ValidatePayload(header, body)
+	if err != webhooks.ErrNoValidSignature {
+		t.Errorf("expected a '%s' error, but got a '%s'", webhooks.ErrNoValidSignature, err)
+	}
+}
+
+func TestWebhookWithEmptySecret(t *testing.T) {
+	defaultTolerance := 180 * time.Second
+	secret := "secret"
+
+	client := webhooks.NewClient(secret, defaultTolerance)
+
+	now := time.Now()
+	body := "{'data': 'foobar'}"
+	header := mockWebhookHeader(now, "", body)
+
+	_, err := client.ValidatePayload(header, body)
+	if err != webhooks.ErrNoValidSignature {
+		t.Errorf("expected a '%s' error, but got a '%s'", webhooks.ErrNoValidSignature, err)
+	}
+}
+
+func TestWebhookWithInvalidHeader(t *testing.T) {
+	defaultTolerance := 180 * time.Second
+	secret := "secret"
+
+	client := webhooks.NewClient(secret, defaultTolerance)
+	body := "{'data': 'foobar'}"
+
+	_, err := client.ValidatePayload("some_junk", body)
+	if err != webhooks.ErrInvalidHeader {
+		t.Errorf("expected a '%s' error, but got a '%s'", webhooks.ErrInvalidHeader, err)
+	}
+}
+
+func TestWebhookWithTimestampOlderThanTolerance(t *testing.T) {
+	defaultTolerance := 180 * time.Second
+	secret := "secret"
+	now := time.Unix(0, 0)
+
+	client := webhooks.NewClient(secret, defaultTolerance)
+	client.SetNow(func() time.Time { return now })
+
+	body := "{'data': 'foobar'}"
+	header := mockWebhookHeader(now.Add(defaultTolerance+time.Second), "", body)
+
+	_, err := client.ValidatePayload(header, body)
+	if err != webhooks.ErrInvalidTimestamp {
+		t.Errorf("expected a '%s' error, but got a '%s'", webhooks.ErrInvalidTimestamp, err)
+	}
+}
+
+func TestWebhookWithInvalidSignature(t *testing.T) {
+	defaultTolerance := 180 * time.Second
+	secret := "secret"
+
+	client := webhooks.NewClient(secret, defaultTolerance)
+
+	now := time.Now()
+	body := "{'data': 'foobar'}"
+	header := mockWebhookHeader(now, secret, body)
+
+	_, err := client.ValidatePayload(header, "{'data': 'bazbiz'}")
+	if err != webhooks.ErrNoValidSignature {
+		t.Errorf("expected a '%s' error, but got a '%s'", webhooks.ErrNoValidSignature, err)
 	}
 }
 


### PR DESCRIPTION
This branch makes some final changes to the `webhooks` package in preparation of a new release. In particular:

* Removing the `ValidatePayload` function in favor of just calling the method on the now exposed `Client`.
* Setting a default `tolerance` (like we do in other SDK's), and allowing it to be changed with a new `SetTolerance` method on `Client`.
* Backfilling test coverage and a few other misc. refactorings.

Also, worth noting that this package implements the construction of its `Client` differently than the others. It uses a constructor (`NewClient`) with setters for customization, instead of the `init` pattern like the others. Personally, I like this pattern better, but will defer to the reviewer if they think this divergence is bad.