### PR TITLE
Add directory_id and idp_id to directory user, as well as the inactive state constant

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -71,6 +71,7 @@ type UserState string
 // Constants that enumerate the state of a Directory User.
 const (
 	Active    UserState = "active"
+	Inactive  UserState = "inactive"
 	Suspended UserState = "suspended"
 )
 
@@ -78,6 +79,12 @@ const (
 type User struct {
 	// The User's unique identifier.
 	ID string `json:"id"`
+
+	// The User's unique identifier assigned by the Directory Provider.
+	IdpID string `json:"idp_id"`
+
+	// The identifier of the Directory the Directory User belongs to.
+	DirectoryID string `json:"directory_id"`
 
 	// The User's username.
 	Username string `json:"username"`


### PR DESCRIPTION
Update from user feedback in this issue: https://github.com/workos-inc/workos-go/issues/136