### PR TITLE
Add support for organization parameter

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -112,7 +112,7 @@ type GetAuthorizationURLOptions struct {
 	// The unique identifier for a WorkOS Connection.
 	Connection string
 
-	//  The organization Id can be used to initiate SSO.
+	//  The unique identifier for a WorkOS Organization.
 	Organization string
 
 	// The callback URL where your app redirects the user-agent after an

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -112,7 +112,7 @@ type GetAuthorizationURLOptions struct {
 	// The unique identifier for a WorkOS Connection.
 	Connection string
 
-	//  The unique identifier for a WorkOS Organization.
+	// The unique identifier for a WorkOS Organization.
 	Organization string
 
 	// The callback URL where your app redirects the user-agent after an

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -93,7 +93,7 @@ func (c *Client) init() {
 // GetAuthorizationURLOptions contains the options to pass in order to generate
 // an authorization url.
 type GetAuthorizationURLOptions struct {
-	// DEPRECATED please use oranization parameter instead
+	// Deprecated: Please use `Organization` parameter instead.
 	// The app/company domain without without protocol (eg. example.com).
 	Domain string
 

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -93,6 +93,7 @@ func (c *Client) init() {
 // GetAuthorizationURLOptions contains the options to pass in order to generate
 // an authorization url.
 type GetAuthorizationURLOptions struct {
+	// DEPRECATED please use oranization parameter instead
 	// The app/company domain without without protocol (eg. example.com).
 	Domain string
 
@@ -110,6 +111,9 @@ type GetAuthorizationURLOptions struct {
 
 	// The unique identifier for a WorkOS Connection.
 	Connection string
+
+	//  The organization Id can be used to initiate SSO.
+	Organization string
 
 	// The callback URL where your app redirects the user-agent after an
 	// authorization code is granted (eg. https://foo.com/callback).
@@ -136,14 +140,15 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 	query.Set("redirect_uri", redirectURI)
 	query.Set("response_type", "code")
 
-	if opts.Domain == "" && opts.Provider == "" && opts.Connection == "" {
-		return nil, errors.New("incomplete arguments: missing connection, domain, or provider")
+	if opts.Domain == "" && opts.Provider == "" && opts.Connection == "" && opts.Organization == "" {
+		return nil, errors.New("incomplete arguments: missing connection, organization, domain, or provider")
 	}
 	if opts.Provider != "" {
 		query.Set("provider", string(opts.Provider))
 	}
 	if opts.Domain != "" {
 		query.Set("domain", opts.Domain)
+		fmt.Println("The `domain` parameter for `getAuthorizationURL` is deprecated. Please use `organization` instead.")
 	}
 	if opts.DomainHint != "" {
 		query.Set("domain_hint", opts.DomainHint)
@@ -153,6 +158,10 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 	}
 	if opts.Connection != "" {
 		query.Set("connection", opts.Connection)
+	}
+
+	if opts.Organization != "" {
+		query.Set("organization", opts.Organization)
 	}
 
 	if opts.State != "" {

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -65,6 +65,16 @@ func TestClientAuthorizeURL(t *testing.T) {
 			expected: "https://api.workos.com/sso/authorize?client_id=client_123&domain=lyft.com&provider=GoogleOAuth&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
 		{
+			scenario: "generate url with organization",
+			options: GetAuthorizationURLOptions{
+				Organization: "organization_123",
+				RedirectURI:  "https://example.com/sso/workos/callback",
+				State:        "custom state",
+			},
+			//CHECK THIS EXPECTED URL
+			expected: "https://api.workos.dev/sso/authorize?client_id=proj_123&organization=organization_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
+		},
+		{
 			scenario: "generate url with DomainHint",
 			options: GetAuthorizationURLOptions{
 				Connection:  "connection_123",

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -71,7 +71,6 @@ func TestClientAuthorizeURL(t *testing.T) {
 				RedirectURI:  "https://example.com/sso/workos/callback",
 				State:        "custom state",
 			},
-			//CHECK THIS EXPECTED URL
 			expected: "https://api.workos.com/sso/authorize?client_id=client_123&organization=organization_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
 		{

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -72,7 +72,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 				State:        "custom state",
 			},
 			//CHECK THIS EXPECTED URL
-			expected: "https://api.workos.dev/sso/authorize?client_id=proj_123&organization=organization_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
+			expected: "https://api.workos.com/sso/authorize?client_id=client_123&organization=organization_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
 		{
 			scenario: "generate url with DomainHint",


### PR DESCRIPTION
This PR adds support for the organization parameter to initiate SSO.

As part of this, the domain parameter has also been deprecated in favor of organization.

Resolves SDK-355.